### PR TITLE
Metrics

### DIFF
--- a/stable/api/Chart.yaml
+++ b/stable/api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for deploying Vulcan api service
+description: A Helm chart for deploying Vulcan api
 name: api
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png

--- a/stable/api/templates/deployment.yaml
+++ b/stable/api/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,6 +22,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -46,6 +54,9 @@ spec:
                   name: {{ include "api.fullname" . }}
                   key: PG_PORT
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -58,21 +69,24 @@ spec:
           - secretRef:
               name: {{ include "api.fullname" . }}
           ports:
-            - name: http
+            - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
             initialDelaySeconds: {{ .Values.probeInitialDelay }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
             initialDelaySeconds: {{ .Values.probeInitialDelay }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/api/values.yaml
+++ b/stable/api/values.yaml
@@ -23,6 +23,9 @@ containerPort: 8080
 probePath: /api/v1/healthcheck
 probeInitialDelay: 5
 
+proxy:
+  enabled: false
+
 conf:
   region: TBD
   debug: "false"

--- a/stable/crontinuous/Chart.yaml
+++ b/stable/crontinuous/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crontinuous
-description: A Helm chart for deploying vulcan crontinuous
+description: A Helm chart for deploying Vulcan crontinuous
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/crontinuous/templates/deployment.yaml
+++ b/stable/crontinuous/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,6 +19,10 @@ spec:
         {{- include "crontinuous.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -27,6 +35,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -36,19 +47,22 @@ spec:
           - configMapRef:
               name: {{ include "crontinuous.fullname" . }}
           ports:
-            - name: http
+            - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/crontinuous/values.yaml
+++ b/stable/crontinuous/values.yaml
@@ -9,6 +9,9 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+proxy:
+  enabled: false
+
 containerPort: 8080
 probePath: /healthcheck
 

--- a/stable/insights/Chart.yaml
+++ b/stable/insights/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: insights
-description: A Helm chart for Kubernetes
+description: A Helm chart for deploying Vulcan insights
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/insights/templates/_haproxy.tpl
+++ b/stable/insights/templates/_haproxy.tpl
@@ -1,0 +1,46 @@
+{{- define "insights.proxy-config-map" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
+data:
+  haproxy.cfg: |
+    global
+      daemon
+      maxconn 64
+      log stdout format raw daemon
+
+    defaults
+      mode http
+      timeout connect 5s
+      timeout client 50s
+      timeout server 50s
+
+    frontend http
+      bind *:{{ .Values.containerPort }}
+      log global
+      option httplog
+      http-request capture req.hdr(Host) len 20
+      http-request capture req.hdr(User-Agent) len 100
+      {{- range .Values.conf.proxies }}
+      {{- if .prefix }}
+      use_backend {{ .name }} if { path -i -m beg {{ .prefix}} }
+      {{- else }}
+      default_backend {{ .name }}
+      {{- end }}
+      {{- end }}
+
+    {{- $dot := . }}
+    {{- range .Values.conf.proxies }}
+    backend {{ .name }}
+      server app 127.0.0.1:{{ .port }} maxconn 32
+    {{- end }}
+
+    frontend stats
+      bind *:9101
+      option http-use-htx
+      http-request use-service prometheus-exporter if { path /metrics }
+      monitor-uri {{ .Values.proxy.probePath | default "/proxyhealthz" }}
+{{- end -}}

--- a/stable/insights/templates/_haproxy.tpl
+++ b/stable/insights/templates/_haproxy.tpl
@@ -18,10 +18,20 @@ data:
       timeout client 50s
       timeout server 50s
 
+    {{- if .Values.proxy.cache }}
+    cache small
+      total-max-size 64     # mb
+      max-age 240           # seconds
+    {{- end }}
+
     frontend http
-      bind *:{{ .Values.containerPort }}
+      bind *:{{ .Values.proxy.port | default "80" }}
       log global
       option httplog
+    {{- if .Values.proxy.cache }}
+      http-request cache-use small
+      http-response cache-store small
+    {{- end }}
       http-request capture req.hdr(Host) len 20
       http-request capture req.hdr(User-Agent) len 100
       {{- range .Values.conf.proxies }}

--- a/stable/insights/templates/config-proxy.yaml
+++ b/stable/insights/templates/config-proxy.yaml
@@ -8,7 +8,7 @@ data:
   haproxy.cfg: |
     global
       daemon
-      maxconn 64
+      maxconn {{ .Values.proxy.maxconn }}
       log stdout format raw daemon
 
     defaults
@@ -31,7 +31,7 @@ data:
       http-request cache-use small
       http-response cache-store small
     {{- end }}
-      http-request capture req.hdr(Host) len 20
+      http-request capture req.hdr(Host) len 50
       http-request capture req.hdr(User-Agent) len 100
       {{- range .Values.conf.proxies }}
       {{- if .prefix }}
@@ -44,7 +44,7 @@ data:
     {{- $dot := . }}
     {{- range .Values.conf.proxies }}
     backend {{ .name }}
-      server app 127.0.0.1:{{ .port }} maxconn 32
+      server app 127.0.0.1:{{ .port }}
     {{- end }}
 
     frontend stats

--- a/stable/insights/templates/config-proxy.yaml
+++ b/stable/insights/templates/config-proxy.yaml
@@ -1,10 +1,9 @@
-{{- define "insights.proxy-config-map" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
-  name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
+    name: {{ include "insights.fullname" . }}-proxy
+  name: {{ include "insights.fullname" . }}-proxy
 data:
   haproxy.cfg: |
     global
@@ -25,7 +24,7 @@ data:
     {{- end }}
 
     frontend http
-      bind *:{{ .Values.proxy.port | default "80" }}
+      bind *:{{ .Values.containerPort }}
       log global
       option httplog
     {{- if .Values.proxy.cache }}
@@ -52,5 +51,4 @@ data:
       bind *:9101
       option http-use-htx
       http-request use-service prometheus-exporter if { path /metrics }
-      monitor-uri {{ .Values.proxy.probePath | default "/proxyhealthz" }}
-{{- end -}}
+      monitor-uri {{ .Values.proxy.probePath }}

--- a/stable/insights/templates/config-proxy.yaml
+++ b/stable/insights/templates/config-proxy.yaml
@@ -48,7 +48,7 @@ data:
     {{- end }}
 
     frontend stats
-      bind *:9101
+      bind *:{{ .Values.proxy.metricsPort }}
       option http-use-htx
       http-request use-service prometheus-exporter if { path /metrics }
       monitor-uri {{ .Values.proxy.probePath }}

--- a/stable/insights/templates/deployment.yaml
+++ b/stable/insights/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-proxy.yaml") . | sha256sum }}
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '9101'
+        prometheus.io/port: '{{ .Values.proxy.metricsPort }}'
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -35,7 +35,7 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPort }}
             - name: metrics
-              containerPort: 9101
+              containerPort: {{ .Values.proxy.metricsPort }}
           volumeMounts:
           - mountPath: /usr/local/etc/haproxy
             readOnly: true

--- a/stable/insights/templates/deployment.yaml
+++ b/stable/insights/templates/deployment.yaml
@@ -1,7 +1,3 @@
-{{- if .Values.proxy.enabled }}
-{{ include "insights.proxy-config-map" . }}
-{{- end }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,10 +14,9 @@ spec:
       labels:
         {{- include "insights.selectorLabels" . | nindent 8 }}
       annotations:
-        {{- if .Values.proxy.enabled }}
-        checksum/config-proxy: {{ include "insights.proxy-config-map" . | sha256sum }}
-        {{ include "proxy-annotations" . | nindent 8 }}
-        {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/config-proxy.yaml") . | sha256sum }}
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9101'
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -34,9 +29,27 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.proxy.enabled }}
-        {{ include "proxy-container" . | nindent 8}}
-        {{- end }}
+        - name: proxy
+          image: haproxy:alpine
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+            - name: metrics
+              containerPort: 9101
+          volumeMounts:
+          - mountPath: /usr/local/etc/haproxy
+            readOnly: true
+            name: config-proxy
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.proxy.probePath }}
+              port: metrics
+            initialDelaySeconds: {{ .Values.proxy.probeInitialDelay }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.proxy.probePath }}
+              port: metrics
+            initialDelaySeconds: {{ .Values.proxy.probeInitialDelay }}
       {{- $dot := . }}
       {{- range .Values.conf.proxies }}
         - name: "{{ $dot.Chart.Name }}-{{ .name }}"
@@ -72,9 +85,10 @@ spec:
           resources:
             {{- toYaml $dot.Values.resources | nindent 12 }}
       {{- end }}
-      {{- if .Values.proxy.enabled }}
-      {{ include "proxy-volumes" . | nindent 6}}
-      {{- end }}
+      volumes:
+      - name: config-proxy
+        configMap:
+          name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/insights/templates/deployment.yaml
+++ b/stable/insights/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "insights.proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,6 +18,10 @@ spec:
       labels:
         {{- include "insights.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "insights.proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -26,6 +34,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
       {{- $dot := . }}
       {{- range .Values.conf.proxies }}
         - name: "{{ $dot.Chart.Name }}-{{ .name }}"
@@ -47,19 +58,22 @@ spec:
             - name: APP_PORT
               value: "{{ .port }}"
           ports:
-            - name: http
+            - name: {{ .name }}
               containerPort: {{ .port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: "{{ $dot.Values.probePath }}"
-              port: http
+              port: {{ .port }}
           readinessProbe:
             httpGet:
               path: "{{ $dot.Values.probePath }}"
-              port: http
+              port: {{ .port }}
           resources:
             {{- toYaml $dot.Values.resources | nindent 12 }}
+      {{- end }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/insights/templates/ingress.yaml
+++ b/stable/insights/templates/ingress.yaml
@@ -10,7 +10,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "insights.labels" . | nindent 4 }}
+{{ include "insights.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -26,10 +26,8 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-        {{- range .Values.conf.proxies }}
-          - path: "{{ .prefix }}/"
+          - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: {{ .port }}
-        {{- end }}
+              servicePort: {{ $svcPort }}
 {{- end }}

--- a/stable/insights/templates/service.yaml
+++ b/stable/insights/templates/service.yaml
@@ -3,15 +3,14 @@ kind: Service
 metadata:
   name: {{ include "insights.fullname" . }}
   labels:
-    {{- include "insights.labels" . | nindent 4 }}
+{{ include "insights.labels" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-  {{- range .Values.conf.proxies }}
-    - port: {{ .port }}
-      targetPort: {{ .port }}
+    - port: {{ .Values.service.port }}
+      targetPort: http
       protocol: TCP
-      name: {{ .name }}
-  {{- end }}
+      name: http
   selector:
-    {{- include "insights.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "insights.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -23,13 +23,13 @@ serviceAccount:
   name:
 
 proxy:
-  port: 8080
-  enabled: true
   cache: true
+  probePath: /healthz
+  probeInitialDelay: 5
 
 conf:
   region: tbd
-  log: "true"
+  log: "false"
   proxies:
     - name: private
       s3Bucket: tbd

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -27,6 +27,7 @@ proxy:
   probePath: /healthz
   probeInitialDelay: 5
   metricsPort: 9101
+  maxconn: 64
 
 conf:
   region: tbd

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -13,12 +13,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 probePath: /healthcheck
+containerPort: 8080
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+proxy:
+  enabled: true
 
 conf:
   region: tbd

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -23,7 +23,9 @@ serviceAccount:
   name:
 
 proxy:
+  port: 8080
   enabled: true
+  cache: true
 
 conf:
   region: tbd

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -26,6 +26,7 @@ proxy:
   cache: true
   probePath: /healthz
   probeInitialDelay: 5
+  metricsPort: 9101
 
 conf:
   region: tbd

--- a/stable/metrics/Chart.yaml
+++ b/stable/metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: metrics
-description: A Helm chart for Kubernetes
+description: A Helm chart for deploying Vulcan metrics
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/persistence/Chart.yaml
+++ b/stable/persistence/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for deploying Vulcan persistence service
+description: A Helm chart for deploying Vulcan persistence
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
 name: persistence
-version: 0.1.0
+version: 0.1.1

--- a/stable/persistence/templates/deployment.yaml
+++ b/stable/persistence/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,6 +22,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -46,32 +54,41 @@ spec:
                   name: {{ include "persistence.fullname" . }}
                   key: POSTGRES_PORT
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: PORT
+            value: "{{ .Values.containerPort }}"
           envFrom:
           - configMapRef:
               name: {{ include "persistence.fullname" . }}
           - secretRef:
               name: {{ include "persistence.fullname" . }}
           ports:
-            - name: http
+            - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
             initialDelaySeconds: {{ .Values.probeInitialDelay }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
             initialDelaySeconds: {{ .Values.probeInitialDelay }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/persistence/values.yaml
+++ b/stable/persistence/values.yaml
@@ -19,9 +19,12 @@ autoscaling:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-containerPort: 3000
+containerPort: 8080
 probePath: /status
 probeInitialDelay: 5
+
+proxy:
+  enabled: false
 
 conf:
   snsTopic: "arn:aws:sns:TBD:TBD:TBD"

--- a/stable/results/Chart.yaml
+++ b/stable/results/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for deploying Vulcan results service
+description: A Helm chart for deploying Vulcan results
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
 name: results
-version: 0.1.0
+version: 0.1.1

--- a/stable/results/templates/deployment.yaml
+++ b/stable/results/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,6 +21,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -29,6 +37,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -38,19 +49,22 @@ spec:
           - configMapRef:
               name: {{ include "results.fullname" . }}
           ports:
-            - name: http
+            - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/results/values.yaml
+++ b/stable/results/values.yaml
@@ -9,6 +9,9 @@ image:
   tag: master
   pullPolicy: IfNotPresent
 
+proxy:
+  enabled: false
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/stable/scanengine/Chart.yaml
+++ b/stable/scanengine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: scanengine
-description: A Helm chart for Kubernetes
+description: A Helm chart for deploying Vulcan scan engine
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/scanengine/templates/deployment.yaml
+++ b/stable/scanengine/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,6 +20,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -44,6 +52,9 @@ spec:
                   name: {{ include "scanengine.fullname" . }}
                   key: PG_PORT
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -56,21 +67,24 @@ spec:
           - secretRef:
               name: {{ include "scanengine.fullname" . }}
           ports:
-            - name: http
+            - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
             initialDelaySeconds: {{ .Values.probeInitialDelay }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
             initialDelaySeconds: {{ .Values.probeInitialDelay }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/scanengine/values.yaml
+++ b/stable/scanengine/values.yaml
@@ -9,6 +9,9 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+proxy:
+  enabled: false
+
 containerPort: 8080
 probePath: /v1/healthcheck
 probeInitialDelay: 5

--- a/stable/stream/Chart.yaml
+++ b/stable/stream/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for deploying Vulcan stream service
+description: A Helm chart for deploying Vulcan stream
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 name: stream
-version: 0.1.0
+version: 0.1.1

--- a/stable/stream/templates/deployment.yaml
+++ b/stable/stream/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,6 +21,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -29,11 +37,13 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-#          command: ['tail', '-f', '/dev/null']
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
           - configMapRef:
@@ -41,19 +51,22 @@ spec:
           - secretRef:
               name: {{ include "stream.fullname" . }}
           ports:
-            - name: http
+            - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/stream/values.yaml
+++ b/stable/stream/values.yaml
@@ -9,6 +9,9 @@ image:
   tag: master
   pullPolicy: IfNotPresent
 
+proxy:
+  enabled: false
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/stable/ui/Chart.yaml
+++ b/stable/ui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ui
-description: A Helm chart for Kubernetes
+description: A Helm chart for deploying Vulcan ui
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/ui/templates/deployment.yaml
+++ b/stable/ui/templates/deployment.yaml
@@ -1,3 +1,7 @@
+{{- if .Values.proxy.enabled }}
+{{ include "proxy-config-map" . }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,6 +18,10 @@ spec:
       labels:
         {{- include "ui.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- if .Values.proxy.enabled }}
+        checksum/config-proxy: {{ include "proxy-config-map" . | sha256sum }}
+        {{ include "proxy-annotations" . | nindent 8 }}
+        {{- end }}
         {{- with .Values.annotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -26,6 +34,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.proxy.enabled }}
+        {{ include "proxy-container" . | nindent 8}}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -34,20 +45,25 @@ spec:
           env:
           - name: API_URL
             value: "{{ .Values.conf.apiUrl }}"
+          - name: PORT
+            value: "{{ .Values.containerPort }}"
           ports:
-            - name: http
+            - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probePath }}
-              port: http
+              port: {{ .Values.containerPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.proxy.enabled }}
+      {{ include "proxy-volumes" . | nindent 6}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/ui/values.yaml
+++ b/stable/ui/values.yaml
@@ -9,7 +9,10 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
-containerPort: 80
+proxy:
+  enabled: false
+
+containerPort: 8080
 probePath: /index.html
 
 autoscaling:
@@ -22,7 +25,6 @@ autoscaling:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-containerPort: 80
 
 conf:
   apiUrl: https://vulcan-api/api/v1/

--- a/stable/vulcan/Chart.yaml
+++ b/stable/vulcan/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vulcan
-description: A Helm chart for Kubernetes
+description: A Helm chart for deploying Vulcan
 home: https://github.com/adevinta/vulcan-charts
 icon: https://raw.githubusercontent.com/adevinta/vulcan-charts/master/docs/logo/vulcan.png
 
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -24,38 +24,38 @@ appVersion: 1.16.0
 
 dependencies:
 - name: results
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../results"
   condition: results.enabled
 - name: stream
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../stream"
   condition: stream.enabled
 - name: persistence
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../persistence"
   condition: persistence.enabled
 - name: api
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../api"
   condition: api.enabled
 - name: crontinuous
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../crontinuous"
   condition: crontinuous.enabled
 - name: scanengine
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../scanengine"
   condition: scanengine.enabled
 - name: insights
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../insights"
   condition: insights.enabled
 - name: ui
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../ui"
   condition: ui.enabled
 - name: metrics
-  version: 0.1.0
+  version: 0.1.1
   repository: "file://../metrics"
   condition: metrics.enabled

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -3,7 +3,7 @@ Override names
 */}}
 {{- define "proxy-annotations" -}}
 prometheus.io/scrape: 'true'
-prometheus.io/port: '{{ .Values.proxy.port | default 80 }}'
+prometheus.io/port: '9101'
 {{- end -}}
 
 {{- define "proxy-config-map" -}}
@@ -16,24 +16,28 @@ metadata:
 data:
   haproxy.cfg: |
     global
-        daemon
-        maxconn 64
-        log stdout format raw daemon
+      daemon
+      maxconn 64
+      log stdout format raw daemon
 
     defaults
-        mode http
-        log global
-        option httplog
-        timeout connect 5s
-        timeout client 50s
-        timeout server 50s
+      mode http
+      log global
+      option httplog
+      timeout connect 5s
+      timeout client 50s
+      timeout server 50s
 
     listen http-in
-        bind *:{{ .Values.proxy.port | default 80 }}
-        http-request set-log-level silent if { path /metrics }
-        http-request use-service prometheus-exporter if { path /metrics }
-        server app 127.0.0.1:{{ .Values.containerPort }} maxconn 32
-        monitor-uri {{ .Values.proxy.probePath | default "/proxyhealthz" }}
+      bind *:{{ .Values.proxy.port | default 80 }}
+      server app 127.0.0.1:{{ .Values.containerPort }} maxconn 32
+
+    frontend stats
+      bind *:9101
+      option http-use-htx
+      http-request use-service prometheus-exporter if { path /metrics }
+      http-request set-log-level silent if { path /metrics }
+      monitor-uri {{ .Values.proxy.probePath | default "/proxyhealthz" }}
 {{- end -}}
 
 {{- define "proxy-container" -}}
@@ -42,6 +46,8 @@ data:
   ports:
     - name: http
       containerPort: {{ .Values.proxy.port | default "80" }}
+    - name: metrics
+      containerPort: 9101
   volumeMounts:
   - mountPath: /usr/local/etc/haproxy
     readOnly: true
@@ -49,12 +55,12 @@ data:
   livenessProbe:
     httpGet:
       path: {{ .Values.proxy.probePath | default "/proxyhealthz" }}
-      port: http
+      port: metrics
     initialDelaySeconds: {{ .Values.proxy.probeInitialDelay | default 5 }}
   readinessProbe:
     httpGet:
       path: {{ .Values.proxy.probePath | default "/proxyhealthz" }}
-      port: http
+      port: metrics
     initialDelaySeconds: {{ .Values.proxy.probeInitialDelay | default 5 }}
 {{- end -}}
 

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -1,0 +1,66 @@
+{{/*
+Override names
+*/}}
+{{- define "proxy-annotations" -}}
+prometheus.io/scrape: 'true'
+prometheus.io/port: '{{ .Values.proxy.port | default 80 }}'
+{{- end -}}
+
+{{- define "proxy-config-map" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
+data:
+  haproxy.cfg: |
+    global
+        daemon
+        maxconn 64
+        log stdout format raw daemon
+
+    defaults
+        mode http
+        log global
+        option httplog
+        timeout connect 5s
+        timeout client 50s
+        timeout server 50s
+
+    listen http-in
+        bind *:{{ .Values.proxy.port | default 80 }}
+        http-request set-log-level silent if { path /metrics }
+        http-request use-service prometheus-exporter if { path /metrics }
+        server app 127.0.0.1:{{ .Values.containerPort }} maxconn 32
+        monitor-uri {{ .Values.proxy.probePath | default "/proxyhealthz" }}
+{{- end -}}
+
+{{- define "proxy-container" -}}
+- name: proxy
+  image: haproxy:alpine
+  ports:
+    - name: http
+      containerPort: {{ .Values.proxy.port | default "80" }}
+  volumeMounts:
+  - mountPath: /usr/local/etc/haproxy
+    readOnly: true
+    name: config-proxy
+  livenessProbe:
+    httpGet:
+      path: {{ .Values.proxy.probePath | default "/proxyhealthz" }}
+      port: http
+    initialDelaySeconds: {{ .Values.proxy.probeInitialDelay | default 5 }}
+  readinessProbe:
+    httpGet:
+      path: {{ .Values.proxy.probePath | default "/proxyhealthz" }}
+      port: http
+    initialDelaySeconds: {{ .Values.proxy.probeInitialDelay | default 5 }}
+{{- end -}}
+
+{{- define "proxy-volumes" -}}
+volumes:
+- name: config-proxy
+  configMap:
+    name: {{ .Release.Name }}-{{ .Chart.Name }}-proxy
+{{- end -}}

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -22,21 +22,22 @@ data:
 
     defaults
       mode http
-      log global
-      option httplog
       timeout connect 5s
       timeout client 50s
       timeout server 50s
 
-    listen http-in
+    listen http
       bind *:{{ .Values.proxy.port | default 80 }}
+      log global
+      option httplog
+      http-request capture req.hdr(Host) len 20
+      http-request capture req.hdr(User-Agent) len 100
       server app 127.0.0.1:{{ .Values.containerPort }} maxconn 32
 
     frontend stats
       bind *:9101
       option http-use-htx
       http-request use-service prometheus-exporter if { path /metrics }
-      http-request set-log-level silent if { path /metrics }
       monitor-uri {{ .Values.proxy.probePath | default "/proxyhealthz" }}
 {{- end -}}
 

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -17,7 +17,7 @@ data:
   haproxy.cfg: |
     global
       daemon
-      maxconn 64
+      maxconn {{ .Values.proxy.maxconn | default 64 }}
       log stdout format raw daemon
 
     defaults
@@ -52,7 +52,7 @@ data:
       default_backend app
 
     backend app
-      server app 127.0.0.1:{{ .Values.containerPort }} maxconn 32
+      server app 127.0.0.1:{{ .Values.containerPort }}
 
     frontend stats
       bind *:{{ .Values.proxy.metricsPort | default 9101 }}

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -23,8 +23,10 @@ data:
     defaults
       mode http
       timeout connect 5s
-      timeout client 50s
-      timeout server 50s
+      timeout client 25s
+      timeout server 25s
+      timeout tunnel 3600s
+      option  http-server-close
 
     {{- if .Values.proxy.cache }}
     cache small
@@ -35,13 +37,18 @@ data:
     frontend http
       bind *:{{ .Values.proxy.port | default 80 }}
       log global
-      option httplog
+      option httplog clf
     {{- if .Values.proxy.cache }}
       http-request cache-use small
       http-response cache-store small
     {{- end }}
-      http-request capture req.hdr(Host) len 20
+      http-request capture req.hdr(Host) len 50
       http-request capture req.hdr(User-Agent) len 100
+
+    {{- if .Values.proxy.logFormat }}
+      log-format "{{ .Values.proxy.logFormat }}"
+    {{- end }}
+
       default_backend app
 
     backend app

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -3,7 +3,7 @@ Override names
 */}}
 {{- define "proxy-annotations" -}}
 prometheus.io/scrape: 'true'
-prometheus.io/port: '9101'
+prometheus.io/port: '{{ .Values.proxy.metricsPort | default 9101 }}'
 {{- end -}}
 
 {{- define "proxy-config-map" -}}
@@ -55,7 +55,7 @@ data:
       server app 127.0.0.1:{{ .Values.containerPort }} maxconn 32
 
     frontend stats
-      bind *:9101
+      bind *:{{ .Values.proxy.metricsPort | default 9101 }}
       option http-use-htx
       http-request use-service prometheus-exporter if { path /metrics }
       monitor-uri {{ .Values.proxy.probePath | default "/healthz" }}
@@ -68,7 +68,7 @@ data:
     - name: http
       containerPort: {{ .Values.proxy.port | default "80" }}
     - name: metrics
-      containerPort: 9101
+      containerPort: {{ .Values.proxy.metricsPort | default 9101 }}
   volumeMounts:
   - mountPath: /usr/local/etc/haproxy
     readOnly: true

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -12,6 +12,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Those values are useless here, could be defined in the dependant charts.
+proxy:
+  enabled: false
+  port: 80
+  probePath: /proxyhealthz
+  probeInitialDelay: 10
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -16,7 +16,7 @@ fullnameOverride: ""
 proxy:
   enabled: false
   port: 80
-  probePath: /proxyhealthz
+  probePath: /healthz
   probeInitialDelay: 10
 
 serviceAccount:


### PR DESCRIPTION
- Allow to add a sidecar with haproxy that exposes access logs and prometheus metrics.
- The config is defined in vulcan chart and reused in all the components except insights.
- For insights it's mandatory to have an haproxy so all the config is inside the chart. This way we simplify sevice/ingress and we get the benefits of metrics, logs and cache.
- We upgrade the chart version 0.1.0 -> 0.1.1