### PR TITLE
Add fine grained probe support

### DIFF
--- a/stable/api/templates/deployment.yaml
+++ b/stable/api/templates/deployment.yaml
@@ -109,18 +109,28 @@ spec:
             - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/api/values.yaml
+++ b/stable/api/values.yaml
@@ -20,9 +20,24 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 containerPort: 8080
-probePath: /api/v1/healthcheck
-probeInitialDelay: 5
-probeTimeout: 3
+
+livenessProbe:
+  enabled: true
+  path: /api/v1/healthcheck
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /api/v1/healthcheck
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 5
 
 proxy:
   enabled: false

--- a/stable/crontinuous/templates/deployment.yaml
+++ b/stable/crontinuous/templates/deployment.yaml
@@ -61,18 +61,28 @@ spec:
             - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/crontinuous/values.yaml
+++ b/stable/crontinuous/values.yaml
@@ -13,9 +13,24 @@ proxy:
   enabled: false
 
 containerPort: 8080
-probePath: /healthcheck
-probeInitialDelay: 2
-probeTimeout: 2
+
+livenessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 5
 
 autoscaling:
   enabled: false

--- a/stable/insights/templates/deployment.yaml
+++ b/stable/insights/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: STRIP_PATH
               value: "{{ $p.prefix }}"
             - name: HEALTHCHECK_PATH
-              value: /healthcheck
+              value: "/healthcheck"
             - name: APP_PORT
               value: "{{ $port }}"
             {{- if $dot.Values.global.minio.enabled }}
@@ -74,7 +74,7 @@ spec:
           {{- if $dot.Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: "/healthcheck"
               port: {{ $port }}
             initialDelaySeconds: {{ $dot.Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ $dot.Values.livenessProbe.periodSeconds }}
@@ -85,7 +85,7 @@ spec:
           {{- if $dot.Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: "/healthcheck"
               port: {{ $port }}
             initialDelaySeconds: {{ $dot.Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ $dot.Values.readinessProbe.periodSeconds }}

--- a/stable/insights/templates/deployment.yaml
+++ b/stable/insights/templates/deployment.yaml
@@ -71,18 +71,28 @@ spec:
             - name: {{ $p.name }}
               containerPort: {{ $port }}
               protocol: TCP
+          {{- if $dot.Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: "{{ $dot.Values.probePath }}"
+              path: {{ $dot.Values.livenessProbe.path }}
               port: {{ $port }}
-            initialDelaySeconds: {{ $dot.Values.probeInitialDelay }}
-            timeoutSeconds: {{ $dot.Values.probeTimeout }}
+            initialDelaySeconds: {{ $dot.Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $dot.Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ $dot.Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ $dot.Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ $dot.Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if $dot.Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: "{{ $dot.Values.probePath }}"
+              path: {{ $dot.Values.readinessProbe.path }}
               port: {{ $port }}
-            initialDelaySeconds: {{ $dot.Values.probeInitialDelay }}
-            timeoutSeconds: {{ $dot.Values.probeTimeout }}
+            initialDelaySeconds: {{ $dot.Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $dot.Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ $dot.Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ $dot.Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ $dot.Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml $dot.Values.resources | nindent 12 }}
       {{- end }}

--- a/stable/insights/templates/deployment.yaml
+++ b/stable/insights/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: STRIP_PATH
               value: "{{ $p.prefix }}"
             - name: HEALTHCHECK_PATH
-              value: "{{ $dot.Values.probePath }}"
+              value: /healthcheck
             - name: APP_PORT
               value: "{{ $port }}"
             {{- if $dot.Values.global.minio.enabled }}
@@ -74,7 +74,7 @@ spec:
           {{- if $dot.Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ $dot.Values.livenessProbe.path }}
+              path: /healthcheck
               port: {{ $port }}
             initialDelaySeconds: {{ $dot.Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ $dot.Values.livenessProbe.periodSeconds }}
@@ -85,7 +85,7 @@ spec:
           {{- if $dot.Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ $dot.Values.readinessProbe.path }}
+              path: /healthcheck
               port: {{ $port }}
             initialDelaySeconds: {{ $dot.Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ $dot.Values.readinessProbe.periodSeconds }}

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -16,7 +16,6 @@ containerPort: 8080
 
 livenessProbe:
   enabled: true
-  path: /healthcheck
   initialDelaySeconds: 5
   timeoutSeconds: 3
   periodSeconds: 10
@@ -25,7 +24,6 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  path: /healthcheck
   initialDelaySeconds: 5
   timeoutSeconds: 3
   periodSeconds: 10

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -12,10 +12,25 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-probePath: /healthcheck
 containerPort: 8080
-probeInitialDelay: 2
-probeTimeout: 2
+
+livenessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 5
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/stable/persistence/templates/deployment.yaml
+++ b/stable/persistence/templates/deployment.yaml
@@ -103,18 +103,28 @@ spec:
           - name: load
             mountPath: /conf
       {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/persistence/values.yaml
+++ b/stable/persistence/values.yaml
@@ -20,9 +20,24 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 containerPort: 8080
-probePath: /status
-probeInitialDelay: 7
-probeTimeout: 4
+
+livenessProbe:
+  enabled: true
+  path: /status
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /status
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
 
 proxy:
   enabled: false

--- a/stable/reportsgenerator/templates/deployment.yaml
+++ b/stable/reportsgenerator/templates/deployment.yaml
@@ -114,18 +114,28 @@ spec:
             - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/reportsgenerator/values.yaml
+++ b/stable/reportsgenerator/values.yaml
@@ -13,9 +13,24 @@ proxy:
   enabled: false
 
 containerPort: 8080
-probePath: /healthcheck
-probeInitialDelay: 5
-probeTimeout: 2
+
+livenessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 5
 
 autoscaling:
   enabled: false

--- a/stable/results/templates/deployment.yaml
+++ b/stable/results/templates/deployment.yaml
@@ -61,18 +61,28 @@ spec:
             - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/results/values.yaml
+++ b/stable/results/values.yaml
@@ -23,9 +23,24 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 containerPort: 8080
-probePath: /healthcheck
-probeInitialDelay: 2
-probeTimeout: 2
+
+livenessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /healthcheck
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 5
 
 global:
   domain: vulcan.local

--- a/stable/scanengine/templates/deployment.yaml
+++ b/stable/scanengine/templates/deployment.yaml
@@ -90,18 +90,28 @@ spec:
             - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/scanengine/values.yaml
+++ b/stable/scanengine/values.yaml
@@ -13,9 +13,24 @@ proxy:
   enabled: false
 
 containerPort: 8080
-probePath: /v1/healthcheck
-probeInitialDelay: 5
-probeTimeout: 2
+
+livenessProbe:
+  enabled: true
+  path: /v1/healthcheck
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /v1/healthcheck
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 5
 
 autoscaling:
   enabled: false

--- a/stable/stream/templates/deployment.yaml
+++ b/stable/stream/templates/deployment.yaml
@@ -79,18 +79,28 @@ spec:
             - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/stream/values.yaml
+++ b/stable/stream/values.yaml
@@ -27,6 +27,24 @@ probePath: /status
 probeInitialDelay: 2
 probeTimeout: 2
 
+livenessProbe:
+  enabled: true
+  path: /status
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /status
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 5
+
 conf:
   logLevel: "DEBUG"
 db:

--- a/stable/ui/templates/deployment.yaml
+++ b/stable/ui/templates/deployment.yaml
@@ -50,18 +50,28 @@ spec:
             - name: {{ ternary "app" "http" .Values.proxy.enabled }}
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probePath }}
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.containerPort }}
-            initialDelaySeconds: {{ .Values.probeInitialDelay }}
-            timeoutSeconds: {{ .Values.probeTimeout }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/stable/ui/values.yaml
+++ b/stable/ui/values.yaml
@@ -13,9 +13,24 @@ proxy:
   enabled: false
 
 containerPort: 8080
-probePath: /index.html
-probeInitialDelay: 2
-probeTimeout: 2
+
+livenessProbe:
+  enabled: true
+  path: /index.html
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 10
+
+readinessProbe:
+  enabled: true
+  path: /index.html
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 5
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Allow to setup liveness / readiness:
-   enabled: true
-   initialDelaySeconds:  10 for pods with migrations else 5s
-   periodSeconds: 5
-   timeoutSeconds: 3s except persistence 5s
-   successThreshold: 1
-   failureThreshold: 10 for liveness / 5 for readiness. (k8s default is 3)

References:

- https://github.com/zegl/kube-score/blob/master/README_PROBES.md
- https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html