### PR TITLE
Fix vulcan-api cors

### DIFF
--- a/stable/api/templates/ingress.yaml
+++ b/stable/api/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ include "api.labels" . | indent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://{{ include "ui.hostname" . }} {{ .Values.ingress.extraCorsAllowOrigin }}"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://{{ include "ui.hostname" . }}"
     nginx.ingress.kubernetes.io/proxy-body-size: 8m
 {{- if .Values.defaultBackend.enabled }}
     nginx.ingress.kubernetes.io/custom-http-errors: {{ .Values.defaultBackend.httpCodes | default "403" | quote }}

--- a/stable/ui/templates/default-backend.yaml
+++ b/stable/ui/templates/default-backend.yaml
@@ -31,7 +31,7 @@ spec:
           image: nginx:alpine
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-        {{- range $name, $value := .Values.extraEnv }}
+        {{- range $name, $value := .Values.defaultBackend.extraEnv }}
           - name: {{ $name }}
             value: {{ $value | quote }}
         {{- end }}

--- a/stable/ui/values.yaml
+++ b/stable/ui/values.yaml
@@ -53,6 +53,8 @@ defaultBackend:
   enabled: true
   index: "<html><body><h1>403 error</h1>Do you have to access through a VPN service?</body></html>"
   httpCodes: "403"
+  # extraEnv:
+  #   FOO: BAR
 
 # extraEnv:
 #   FOO: BAR


### PR DESCRIPTION
- Remove the useless parameter extraCorsAllowOrigin (only one is accepted)
- Moves the extraEnv inside the defaultBackend.
