### PR TITLE
Remove hardcoded cors policy

### DIFF
--- a/stable/api/templates/ingress.yaml
+++ b/stable/api/templates/ingress.yaml
@@ -12,8 +12,6 @@ metadata:
   labels:
 {{ include "api.labels" . | indent 4 }}
   annotations:
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://{{ include "ui.hostname" . }}"
     nginx.ingress.kubernetes.io/proxy-body-size: 8m
 {{- if .Values.defaultBackend.enabled }}
     nginx.ingress.kubernetes.io/custom-http-errors: {{ .Values.defaultBackend.httpCodes | default "403" | quote }}


### PR DESCRIPTION
The annotation nginx.ingress.kubernetes.io/cors-allow-origin only allows a domain or *. If we want to allow multiple domains we have to leverage the **configuration-snippet**
In order to allow the max flexibility, we decided to remove the hardcoded annotations that only allow one origin. 

In case we need cors:

- For one domain is just add the annotations to the values
```
api:
  ingress:
    annotations:
      nginx.ingress.kubernetes.io/enable-cors: "true"
      nginx.ingress.kubernetes.io/cors-allow-origin: "https://domain"
```
- For a custom solution with a regex 
```
api:
  ingress:
    annotations:
      nginx.ingress.kubernetes.io/configuration-snippet: |
        if ($http_origin ~ '^https?:\/\/(domain1|domain2)(:[0-9]+)?$') {
          set $allow_origin $http_origin;
        }

        # Cors Preflight methods needs additional options and different Return Code
        if ($request_method = 'OPTIONS') {
          more_set_headers 'Access-Control-Allow-Origin: $allow_origin';
          more_set_headers 'Access-Control-Allow-Credentials: true';
          more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
          more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-Client-Identifier';
          more_set_headers 'Access-Control-Max-Age: 1728000';
          more_set_headers 'Content-Type: text/plain charset=UTF-8';
          more_set_headers 'Content-Length: 0';
          return 204;
        }

        more_set_headers 'Access-Control-Allow-Origin: $allow_origin';
        more_set_headers 'Access-Control-Allow-Credentials: true';
        more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
        more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-Client-Identifier';

```
