### PR TITLE
Allow to set custom haproxy timeouts

### DIFF
--- a/stable/insights/templates/config-proxy.yaml
+++ b/stable/insights/templates/config-proxy.yaml
@@ -13,10 +13,10 @@ data:
 
     defaults
       mode http
-      timeout connect {{ .Values.proxy.timeoutConnect | default 5s }}
-      timeout client {{ .Values.proxy.timeoutClient | default 25s }}
-      timeout server {{ .Values.proxy.timeoutServer | default 25s }}
-      timeout tunnel {{ .Values.proxy.timeoutTunnel | default 3600s }}
+      timeout connect {{ .Values.proxy.timeoutConnect | default "5s" }}
+      timeout client {{ .Values.proxy.timeoutClient | default "25s" }}
+      timeout server {{ .Values.proxy.timeoutServer | default "25s" }}
+      timeout tunnel {{ .Values.proxy.timeoutTunnel | default "3600s" }}
       option  http-server-close
 
     {{- if .Values.proxy.cache }}

--- a/stable/insights/templates/config-proxy.yaml
+++ b/stable/insights/templates/config-proxy.yaml
@@ -13,10 +13,10 @@ data:
 
     defaults
       mode http
-      timeout connect 5s
-      timeout client 25s
-      timeout server 25s
-      timeout tunnel 3600s
+      timeout connect {{ .Values.proxy.timeoutConnect | default 5s }}
+      timeout client {{ .Values.proxy.timeoutClient | default 25s }}
+      timeout server {{ .Values.proxy.timeoutServer | default 25s }}
+      timeout tunnel {{ .Values.proxy.timeoutTunnel | default 3600s }}
       option  http-server-close
 
     {{- if .Values.proxy.cache }}

--- a/stable/insights/values.yaml
+++ b/stable/insights/values.yaml
@@ -53,6 +53,10 @@ proxy:
   probeInitialDelay: 5
   metricsPort: 9101
   maxconn: 64
+  # timeoutConnect: 5s
+  # timeoutClient: 25s
+  # timeoutServer: 25s
+  # timeoutTunnel: 3600s
 
 conf:
   region:

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -26,10 +26,10 @@ data:
 
     defaults
       mode http
-      timeout connect {{ .Values.proxy.timeoutConnect | default 5s }}
-      timeout client {{ .Values.proxy.timeoutClient | default 25s }}
-      timeout server {{ .Values.proxy.timeoutServer | default 25s }}
-      timeout tunnel {{ .Values.proxy.timeoutTunnel | default 3600s }}
+      timeout connect {{ .Values.proxy.timeoutConnect | default "5s" }}
+      timeout client {{ .Values.proxy.timeoutClient | default "25s" }}
+      timeout server {{ .Values.proxy.timeoutServer | default "25s" }}
+      timeout tunnel {{ .Values.proxy.timeoutTunnel | default "3600s" }}
       option  http-server-close
 
     {{- if .Values.proxy.cache }}

--- a/stable/vulcan/templates/_haproxy.tpl
+++ b/stable/vulcan/templates/_haproxy.tpl
@@ -26,10 +26,10 @@ data:
 
     defaults
       mode http
-      timeout connect 5s
-      timeout client 25s
-      timeout server 25s
-      timeout tunnel 3600s
+      timeout connect {{ .Values.proxy.timeoutConnect | default 5s }}
+      timeout client {{ .Values.proxy.timeoutClient | default 25s }}
+      timeout server {{ .Values.proxy.timeoutServer | default 25s }}
+      timeout tunnel {{ .Values.proxy.timeoutTunnel | default 3600s }}
       option  http-server-close
 
     {{- if .Values.proxy.cache }}

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -110,6 +110,10 @@ defaults:
       probePath: /healthz
       probeInitialDelay: 5
       probeTimeoutSeconds: 3
+      # timeoutConnect: 5s
+      # timeoutClient: 25s
+      # timeoutServer: 25s
+      # timeoutTunnel: 3600s
       lifecycle:
         preStopSleep: 30
       resources: {}


### PR DESCRIPTION
Allows to set timeouts per component:

Example:
```json
api:
  proxy:
    timeoutConnect: 6s
    timeoutClient: 20s
    timeoutServer: 50s
    timeoutTunnel: 3700s

insights:
  proxy:
    timeoutConnect: 5s
    timeoutClient: 10s
    timeoutServer: 15s

```