### PR TITLE
Add new crontinuous config params

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.org/adevinta/vulcan-charts.svg?branch=master)](https://travis-ci.org/adevinta/vulcan-charts)
-
 https://adevinta.github.io/vulcan-charts
 
 ## Vulcan Charts

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.org/adevinta/vulcan-charts.svg?branch=master)](https://travis-ci.org/adevinta/vulcan-charts)
+
 https://adevinta.github.io/vulcan-charts
 
 ## Vulcan Charts

--- a/stable/crontinuous/templates/deployment.yaml
+++ b/stable/crontinuous/templates/deployment.yaml
@@ -51,13 +51,13 @@ spec:
           - name: VULCAN_USER
             value: {{ .Values.conf.vulcanUser }}
           - name: ENABLE_TEAMS_WHITELIST_SCAN
-            value: {{ .Values.conf.enableTeamsWhitelistScan }}
+            value: {{ .Values.conf.enableTeamsWhitelistScan | quote }}
           - name: TEAMS_WHITELIST_SCAN
-            value: {{ .Values.conf.teamsWhitelistScan }}
+            value: {{ .Values.conf.teamsWhitelistScan | quote}}
           - name: ENABLE_TEAMS_WHITELIST_REPORT
-            value: {{ .Values.conf.enableTeamsWhitelistReport }}
+            value: {{ .Values.conf.enableTeamsWhitelistReport | quote }}
           - name: TEAMS_WHITELIST_REPORT
-            value: {{ .Values.conf.teamsWhitelistReport }}
+            value: {{ .Values.conf.teamsWhitelistReport | quote }}
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/crontinuous/templates/deployment.yaml
+++ b/stable/crontinuous/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
             value: {{ .Values.conf.vulcanApi | default (include "vulcanApi" .) }}
           - name: VULCAN_USER
             value: {{ .Values.conf.vulcanUser }}
+          - name: ENABLE_TEAMS_WHITELIST_SCAN
+            value: {{ .Values.conf.enableTeamsWhitelistScan }}
+          - name: TEAMS_WHITELIST_SCAN
+            value: {{ .Values.conf.teamsWhitelistScan }}
+          - name: ENABLE_TEAMS_WHITELIST_REPORT
+            value: {{ .Values.conf.enableTeamsWhitelistReport }}
+          - name: TEAMS_WHITELIST_REPORT
+            value: {{ .Values.conf.teamsWhitelistReport }}
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/crontinuous/values.yaml
+++ b/stable/crontinuous/values.yaml
@@ -46,6 +46,10 @@ conf:
   crontinuousBucket: tbd
   vulcanUser: tbd
   vulcanApi:  # http://host/api
+  enableTeamsWhitelistScan: false
+  teamsWhitelistScan: '[]'
+  enableTeamsWhitelistReport: false
+  teamsWhitelistReport: '[]'
 
 # extraEnv:
 #   FOO: BAR

--- a/stable/crontinuous/values.yaml
+++ b/stable/crontinuous/values.yaml
@@ -46,9 +46,9 @@ conf:
   crontinuousBucket: tbd
   vulcanUser: tbd
   vulcanApi:  # http://host/api
-  enableTeamsWhitelistScan: false
+  enableTeamsWhitelistScan: "false"
   teamsWhitelistScan: '[]'
-  enableTeamsWhitelistReport: false
+  enableTeamsWhitelistReport: "false"
   teamsWhitelistReport: '[]'
 
 # extraEnv:


### PR DESCRIPTION
This PR adds new vulcan-crontinuous parameters in order to whitelist scheduling of scans and reports per team ID.