### PR TITLE
Add live report config params

### DIFF
--- a/stable/api/templates/deployment.yaml
+++ b/stable/api/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
             value: "{{ .Values.conf.reports.apiUrl | default (include "reportsgeneratorUrl" .) }}"
           - name: SCAN_REDIRECT_URL
             value: "{{ .Values.conf.reports.redirectUrl }}"
+          - name: VULCAN_UI_URL
+            value: "{{ .Values.conf.reports.vulcanUIUrl }}"
           - name: PERSISTENCE_HOST
             value: "{{ .Values.conf.persistenceHost | default  (include "persistenceHost" .) }}"
           - name: VULNERABILITYDB_URL

--- a/stable/api/values.yaml
+++ b/stable/api/values.yaml
@@ -56,6 +56,7 @@ conf:
   reports:
     snsArn: arn:aws:sns:TBD:TBD:TBD
     redirectUrl:
+    vulcanUIUrl:
   vulnerabilityDbUrl: vulnerabilitydbapi # the current FIAAS
   persistenceHost:
   crontinuousUrl:

--- a/stable/crontinuous/templates/deployment.yaml
+++ b/stable/crontinuous/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
             value: {{ .Values.conf.vulcanApi | default (include "vulcanApi" .) }}
           - name: VULCAN_USER
             value: {{ .Values.conf.vulcanUser }}
+          - name: ENABLE_TEAMS_WHITELIST_SCAN
+            value: {{ .Values.conf.enableTeamsWhitelistScan | quote }}
+          - name: TEAMS_WHITELIST_SCAN
+            value: {{ .Values.conf.teamsWhitelistScan | quote}}
+          - name: ENABLE_TEAMS_WHITELIST_REPORT
+            value: {{ .Values.conf.enableTeamsWhitelistReport | quote }}
+          - name: TEAMS_WHITELIST_REPORT
+            value: {{ .Values.conf.teamsWhitelistReport | quote }}
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/crontinuous/values.yaml
+++ b/stable/crontinuous/values.yaml
@@ -46,6 +46,10 @@ conf:
   crontinuousBucket: tbd
   vulcanUser: tbd
   vulcanApi:  # http://host/api
+  enableTeamsWhitelistScan: "false"
+  teamsWhitelistScan: '[]'
+  enableTeamsWhitelistReport: "false"
+  teamsWhitelistReport: '[]'
 
 # extraEnv:
 #   FOO: BAR

--- a/stable/reportsgenerator/templates/deployment.yaml
+++ b/stable/reportsgenerator/templates/deployment.yaml
@@ -96,6 +96,8 @@ spec:
           - name: SCAN_REDIRECT_URL
             value: "{{ .Values.conf.generators.scan.redirectUrl }}"
           {{- end }}
+          - name: LIVEREPORT_EMAIL_SUBJECT
+          value: "{{ .Values.conf.generators.livereport.emailSubject }}"
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/reportsgenerator/templates/deployment.yaml
+++ b/stable/reportsgenerator/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
             value: "{{ .Values.conf.generators.scan.redirectUrl }}"
           {{- end }}
           - name: LIVEREPORT_EMAIL_SUBJECT
-          value: "{{ .Values.conf.generators.livereport.emailSubject }}"
+            value: "{{ .Values.conf.generators.livereport.emailSubject }}"
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/reportsgenerator/values.yaml
+++ b/stable/reportsgenerator/values.yaml
@@ -60,6 +60,8 @@ conf:
       vulcanUi: # https://vulcan-www
       viewReport: # vulcan-api/api/v1/report?team_id=%s&scan_id=%s
       redirectUrl: # https://public-redirect/index.html?reportUrl=
+    livereport:
+      emailSubject: #Vulcan Digest
 
 db:
   internal: false

--- a/stable/ui/templates/deployment.yaml
+++ b/stable/ui/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             value: "{{ printf "https://%s/api/v1/" ( include "api.hostname" . ) }}"
           - name: PORT
             value: "{{ .Values.containerPort }}"
+          - name: LIVE_REPORT_WHITELIST
+            value: {{ .Values.conf.liveReportWhitelist | quote }}
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/ui/values.yaml
+++ b/stable/ui/values.yaml
@@ -45,6 +45,7 @@ proxy:
 
 conf:
   apiUrl: # https://vulcan-api/api/v1/
+  liveReportWhitelist: '[]'
 
 defaultBackend:
   enabled: true


### PR DESCRIPTION
This PR adds the new required config params for the live report functionality. Including:
- New params for crontinuous scheduling of digest reports.
- New params for vulcan API's reference for UI URL in order to build the digest email content link.
- New params for vulcan-reports-generator in order to support digest report.