### PR TITLE
Remove UI live report whitelist param

### DIFF
--- a/stable/ui/templates/deployment.yaml
+++ b/stable/ui/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
             value: "{{ .Values.conf.apiUrl }}"
           - name: PORT
             value: "{{ .Values.containerPort }}"
-          - name: LIVE_REPORT_WHITELIST
-            value: {{ .Values.conf.liveReportWhitelist | quote }}
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/ui/values.yaml
+++ b/stable/ui/values.yaml
@@ -45,7 +45,6 @@ proxy:
 
 conf:
   apiUrl: # https://vulcan-api/api/v1/
-  liveReportWhitelist: '[]'
 
 # extraEnv:
 #   FOO: BAR


### PR DESCRIPTION
This PR removes the live report whitelist param for the vulcan UI.