### PR TITLE
Reportsgenerator uses scanengine instead persistence

### DIFF
--- a/stable/api/templates/deployment.yaml
+++ b/stable/api/templates/deployment.yaml
@@ -81,9 +81,9 @@ spec:
           - name: SAML_TRUSTED_DOMAINS
             value: {{ printf "'%s'" .Values.conf.saml.trustedDomains }}
           - name: SCANENGINE_URL
-            value: "{{ .Values.conf.scanengineUrl | default  (include "scanengineUrl" .) }}"
+            value: "{{ .Values.conf.scanengineUrl | default ( printf "%s/v1/" (include "scanengineUrl" .) ) }}"
           - name: SCHEDULER_URL
-            value: "{{ .Values.conf.schedulerUrl | default  (include "crontinuousUrl" .) }}"
+            value: "{{ .Values.conf.schedulerUrl | default (include "crontinuousUrl" .) }}"
           - name: SQS_QUEUE_ARN
             value: "{{ .Values.conf.queueArn }}"
           - name: REPORTS_SNS_ARN

--- a/stable/reportsgenerator/templates/_common.yaml
+++ b/stable/reportsgenerator/templates/_common.yaml
@@ -30,7 +30,8 @@ http
 {{- .Values.conf.ses.region -}}
 {{- end -}}
 
-{{- define "persistenceUrl" -}}
+{{- define "scanengineUrl" -}}
+{{- .Values.conf.scanengineUrl -}}
 {{- end -}}
 
 {{- define "postgresqlHost" -}}

--- a/stable/reportsgenerator/templates/deployment.yaml
+++ b/stable/reportsgenerator/templates/deployment.yaml
@@ -84,8 +84,8 @@ spec:
             value: "{{ .Values.conf.generators.scan.privateBucket }}"
           - name: SCAN_GA_ID
             value: "{{ .Values.conf.generators.scan.gaId }}"
-          - name: PERSISTENCE_ENDPOINT
-            value: "{{ .Values.conf.persistenceUrl | default (include "persistenceUrl" .) }}"
+          - name: PERSISTENCE_ENDPOINT  # We keep this PERSISTENCE variable for compatibility
+            value: "{{ .Values.conf.scanengineUrl | default (include "scanengineUrl" .) }}"
           - name: RESULTS_ENDPOINT
             value: "{{ .Values.conf.resultsUrl | default (include "resultsUrl" .) }}"
           - name: SCAN_PROXY_ENDPOINT

--- a/stable/reportsgenerator/values.yaml
+++ b/stable/reportsgenerator/values.yaml
@@ -49,7 +49,7 @@ conf:
   logLevel: "info"
   queueArn: arn:aws:sqs:TBD:TBD:TBD
   queueName: TBD
-  persistenceUrl:
+  scanengineUrl:
   resultsUrl:
   ses:
     region:

--- a/stable/vulcan/templates/_common.tpl
+++ b/stable/vulcan/templates/_common.tpl
@@ -102,7 +102,7 @@ Override names
 {{- end -}}
 
 {{- define "scanengineUrl" -}}
-{{- printf "http://%s-scanengine/v1/" .Release.Name -}}
+{{- printf "http://%s-scanengine" .Release.Name -}}
 {{- end -}}
 
 {{- define "crontinuousUrl" -}}


### PR DESCRIPTION
Persistence no longer has the information of the scans/checks in favour of scan engine.
The slug of the URL is the same, we just need to change the internal linking.
Also we go an step towards cleaning the "/v1" references in the helm charts.