### PR TITLE
Add API default owners param

### DIFF
--- a/stable/api/templates/deployment.yaml
+++ b/stable/api/templates/deployment.yaml
@@ -80,6 +80,8 @@ spec:
             value: "{{ .Values.conf.saml.callback }}"
           - name: SAML_TRUSTED_DOMAINS
             value: {{ printf "'%s'" .Values.conf.saml.trustedDomains }}
+          - name: DEFAULT_OWNERS
+            value: "{{ .Values.conf.defaultOwners }}"
           - name: SCANENGINE_URL
             value: "{{ .Values.conf.scanengineUrl | default ( printf "%s/v1/" (include "scanengineUrl" .) ) }}"
           - name: SCHEDULER_URL

--- a/stable/api/values.yaml
+++ b/stable/api/values.yaml
@@ -57,6 +57,7 @@ conf:
     trustedDomains: # '["vulcan-api"]'
   log:
     level: INFO
+  defaultOwners: '[]'
   queueArn: arn:aws:sqs:local:TBD:TBD
   reports:
     snsArn: arn:aws:sns:TBD:TBD:TBD


### PR DESCRIPTION
This PR includes the Vulcan API default owners list as a chart configuration parameter.