### PR TITLE
Remove deprecated persistence params

### DIFF
--- a/stable/persistence/templates/_common.yaml
+++ b/stable/persistence/templates/_common.yaml
@@ -23,10 +23,6 @@
 http
 {{- end -}}
 
-{{- define "region" -}}
-{{- .Values.conf.region -}}
-{{- end -}}
-
 {{- define "postgresqlHost" -}}
 {{ .Values.db.host }}
 {{- end -}}

--- a/stable/persistence/templates/deployment.yaml
+++ b/stable/persistence/templates/deployment.yaml
@@ -74,24 +74,8 @@ spec:
           {{- end }}
           - name: LOG_LEVEL
             value: "{{ .Values.conf.logLevel }}"
-          - name: STREAM_CHANNEL
-            value: "{{ .Values.conf.channel }}"
-          - name: REGION
-            value: "{{ .Values.conf.region | default (include "region" .) }}"
-          - name: SCANS_BUCKET
-            value: "{{ .Values.conf.s3Scans }}"
-          - name: SNS_TOPIC_ARN
-            value: "{{ .Values.conf.snsTopic }}"
-          - name: AWS_REGION
-            value: "{{ .Values.conf.region | default (include "region" .) }}"
-          - name: NESSUS_CHECK_QUEUE
-            value: "{{ .Values.conf.nessusCheckQueue }}"
           - name: RAILS_MAX_THREADS
             value: "{{ .Values.conf.railsMaxThreads }}"
-          - name: AWS_CREATE_CHECKS_SQS_URL
-            value: "{{ .Values.conf.awsCreateChecksSqsUrl | default (printf "%s/%s" (include "sqsEndpoint" .) .Values.conf.awsCreateChecksSqsName) }}"
-          - name: AWS_CREATE_CHECKS_WORKERS
-            value: "{{ .Values.conf.awsCreateChecksWorkers }}"
         {{- include "common-envs" . | nindent 10 }}
         {{- range $name, $value := .Values.extraEnv }}
           - name: {{ $name }}

--- a/stable/persistence/values.yaml
+++ b/stable/persistence/values.yaml
@@ -46,15 +46,9 @@ readinessProbe:
 
 conf:
   logLevel:
-  snsTopic: "arn:aws:sns:local:TBD:TBD"
-  s3Scans: TBD
   secretKeyBase: TBDTBD
-  channel: events
   nessusCheckQueue: TBD
   railsMaxThreads: 4
-  # awsCreateChecksSqsUrl: http://localhost/VulcanK8SPersistenceChecks
-  awsCreateChecksSqsName: VulcanK8SPersistenceChecks
-  awsCreateChecksWorkers: 4
 
 db:
   internal: false


### PR DESCRIPTION
This PR removes deprecated configuration parameters for vulcan-persistence due to Vulcan v2 refactor.