### PR TITLE
Maintenance version

### DIFF
--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -20,7 +20,7 @@ redis:
 
 results:
   conf:
-    linkBase: https://results.chart-example.local
+    linkBase: https://results.vulcan.local
   ingress:
     enabled: true
     hosts:

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -53,6 +53,8 @@ api:
   ingress:
     enabled: true
     annotations:
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/cors-allow-origin: "https://www.vulcan.local"
       nginx.ingress.kubernetes.io/proxy-body-size: 8m
     hosts:
       - host: www.vulcan.local

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -890,7 +890,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1039,7 +1039,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1146,7 +1146,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1400,7 +1400,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1539,7 +1539,7 @@ spec:
                       cpu: 100m
                       memory: 128Mi
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1714,7 +1714,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1837,7 +1837,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2029,7 +2029,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2136,7 +2136,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2330,7 +2330,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -818,28 +818,6 @@ spec:
       app.kubernetes.io/instance: vulcan
       app.kubernetes.io/name: ui
 ---
-# Source: vulcan/templates/vulndb/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: myrelease-vulcan-vulndb
-  labels:
-    helm.sh/chart: vulcan-0.3.1
-    app.kubernetes.io/instance: vulcan
-    app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: vulndb
-spec:
-  type: ClusterIP
-  ports:
-    - port: 80
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-      app.kubernetes.io/instance: vulcan
-      app.kubernetes.io/name: vulndb
----
 # Source: vulcan/templates/vulndbapi/service.yaml
 apiVersion: v1
 kind: Service

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -37,7 +37,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-dogstatsd
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -52,7 +52,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -68,7 +68,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -99,7 +99,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -114,7 +114,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -129,7 +129,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -144,7 +144,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -159,7 +159,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-api-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -203,7 +203,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-crontinuous-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -246,7 +246,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -261,7 +261,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-insights-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -313,7 +313,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-persistence-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -357,7 +357,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-reportsgenerator-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -401,7 +401,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-results-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -445,7 +445,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-scanengine-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -489,7 +489,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-stream-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -533,7 +533,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-ui-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -577,7 +577,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-vulndbapi-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -626,7 +626,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -648,7 +648,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -670,7 +670,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -692,7 +692,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -714,7 +714,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -736,7 +736,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -758,7 +758,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -780,7 +780,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -802,7 +802,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -824,7 +824,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -846,7 +846,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -862,8 +862,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: api
       annotations:
-        checksum/secrets: ba698632fda358e6cebd9d853909276279544b74be653e416f4dfe3979275064
-        checksum/config-proxy: 3ab03916c412bb50e850489b4e4feede56794e065028f852d99c09568529e3a7
+        checksum/secrets: 4c42ef1bd4d262cc8cfed5e9fdbf77af0d9d9284028dc8282c237b637f72e834
+        checksum/config-proxy: cb0ea6cf2e742c5f7abedfef344f81b1e56f4b9820dd7e058fbf0dfd4f7218d4
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/APIRole
@@ -1014,7 +1014,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1030,8 +1030,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: crontinuous
       annotations:
-        checksum/secrets: 1e63100b5ad29e3db7a6d27e146338fa8d19d13b7cdd89ecabfdca632baafec9
-        checksum/config-proxy: 8301c4eee9fd614a36fe4daa80caf32cbf3bd1824c565bde1ec95bce48cb01a4
+        checksum/secrets: 2d4aba7454af3758198f8dce339ec10c413ad01f11d55de37d805ade530d9984
+        checksum/config-proxy: 7a9ff685af6768c75cfc9a7722014b180663701e41032f1bb06e714b50bc63b3
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/CrontinuousRole
@@ -1122,7 +1122,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1138,7 +1138,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: insights
       annotations:
-        checksum/config: 703ed50cec41de44e0e3758a3bef40eb3f407e0dee9da314572ad3ff74d04d58
+        checksum/config: ae78f3bdf3bfc91f4fe4e4f8c9a5457819610ea3baa34204a633a21e45b04113
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/InsightsRole
@@ -1258,7 +1258,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1356,7 +1356,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1372,8 +1372,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: persistence
       annotations:
-        checksum/secrets: f774b1daff04bfeeafe2b7e33112fa9ea752b7327f070a6025b81c4b5176a2cd
-        checksum/config-proxy: 58945b489b6c74b3ba3f571c98a03211e54de3e50a74b66af08513373be110e6
+        checksum/secrets: d0199fc624d118f28986b1e7e385e804271c10409aec53971a5250aaec714aed
+        checksum/config-proxy: 3151e6a108ce8bd5b672ea6f322cfdbdb956427df391ef2aebbc022bffb77e0e
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/PersistenceRole
@@ -1488,7 +1488,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1504,8 +1504,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: reportsgenerator
       annotations:
-        checksum/secrets: 259ca9b2346c249c856db375bbda938d3b6a8c733774d114e75ad3962359014b
-        checksum/config-proxy: 89649aeee9c8a9b2c4088e7e6b7bee4c0ded593ab4f6e91a576bb734865548d7
+        checksum/secrets: 9287b83def5219a79123a600c2eb5ec18337f81309f2e1222e4b17535d2a0f06
+        checksum/config-proxy: c1dd9fc8495a31037e3e64aed4eb09945ecde91a29fd2766c6397a1c0d0c32fb
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/ReportsGeneratorRole
@@ -1681,7 +1681,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1697,7 +1697,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: results
       annotations:
-        checksum/config-proxy: 251d2ce669b075656d4ef8a27f88765b497795a70c416156988df265d315d3a1
+        checksum/config-proxy: 889a9e304015fded6ad60e3ea92495b8c3b71461039bdb6b414317fbd332e7b0
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/ResultsRole
@@ -1793,7 +1793,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1809,8 +1809,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: scanengine
       annotations:
-        checksum/secrets: 23a09fca9d2d2ae7030756bcb75f2d134f9cf0a8a112a1e1a65cbb101a2698a9
-        checksum/config-proxy: e058b300bc9a692fbf5ae7184f06984f054330572fd8580753aed227afc6e1f6
+        checksum/secrets: 8a5a422a2769d49a4aa833373dfa0f4170dd1d700866d46b1ff331eb963cb9e2
+        checksum/config-proxy: bdfccf5fa5abe44073d6aeb882965d1a15b0b0587d0131fb95a279bcbbfd8e99
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/ScanEngineRole
@@ -1943,7 +1943,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-sqsexporter
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1995,7 +1995,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2011,8 +2011,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: stream
       annotations:
-        checksum/secrets: 95d3611075a65ef02ae02fa5e62f737a3b11a5e3980f9a8a865e300a2ed7b472
-        checksum/config-proxy: 5a9e38009bf02dcb037c3e0c1e3e3aa1c69cecc0356c4273afb8de6bb976a69b
+        checksum/secrets: b75aae73d2c9213717df2b741ef75b720ddf5d8dad974d26ffa2b22291255fd6
+        checksum/config-proxy: ac1119a231287803c9fdb74c0c0e0e123662655f5cca5a15acbfba31c2f20677
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/StreamRole
@@ -2113,7 +2113,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2129,7 +2129,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: ui
       annotations:
-        checksum/config-proxy: bd854a71f46a654aa37dcf994ee5c0889aec9daa629cbeefea2323d9ad21b4c4
+        checksum/config-proxy: 3af3dd568f76e45913660b45da6ca7cb5a9de0491e386a8a9e7d596c0528093e
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2214,7 +2214,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2230,7 +2230,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: vulndb
       annotations:
-        checksum/secrets: 9290a0889e7344d9cf05e46e983ecb59e393df76294e3000e04de1b8c1c0f347
+        checksum/secrets: c6899b646c7d2ecf8d40d8eead5e0b40ab4beadb450fa660b04938e5b46595e3
         
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/VulnDBRole
     spec:
@@ -2296,7 +2296,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2312,8 +2312,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: vulndbapi
       annotations:
-        checksum/secrets: 72e0a0cbf509928844e71286630c0a5516accd69a1b6c6e32bb4a704add36af0
-        checksum/config-proxy: ca9deb91c33173e28aa87e817583c7f55799c8201d3ce8c7ddf5560d90c037c3
+        checksum/secrets: eb5b5da38d0605a90fcfd11277c030b9c374c262eacc0cda3eb96c485dbcb7c8
+        checksum/config-proxy: bd3a7f5876f09c3b25d9c58aaf0ea3251f2554bd304350609223f53d46f95e8c
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2411,7 +2411,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2435,7 +2435,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2459,7 +2459,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2483,7 +2483,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2507,7 +2507,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2531,7 +2531,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2561,7 +2561,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2597,7 +2597,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2625,7 +2625,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2653,7 +2653,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2682,7 +2682,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -1391,7 +1391,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1555,7 +1555,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1714,7 +1714,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -1968,7 +1968,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2115,7 +2115,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2278,7 +2278,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2413,7 +2413,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2609,7 +2609,7 @@ spec:
               name: dogstatsd
               protocol: UDP
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2710,7 +2710,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http
@@ -2903,7 +2903,7 @@ spec:
       containers:
         
         - name: proxy
-          image: "haproxy:2.3.10-alpine"
+          image: "haproxy:2.3.13-alpine"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -2331,7 +2331,7 @@ spec:
           - name: BUCKET_LOGS
             value: "logs"
           - name: LINK_BASE
-            value: "https://results.chart-example.local/v1"
+            value: "https://results.vulcan.local/v1"
           
           - name: AWS_S3_ENDPOINT
             value: "http://myrelease-minio"

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -854,13 +854,13 @@ metadata:
     app.kubernetes.io/instance: myrelease
     app.kubernetes.io/managed-by: Helm
 spec:
-  type: NodePort
-  externalTrafficPolicy: "Cluster"
+  type: ClusterIP
   
   ports:
     - name: minio
       port: 80
       targetPort: minio
+      nodePort: null
   selector:
     app.kubernetes.io/name: minio
     app.kubernetes.io/instance: myrelease
@@ -1210,28 +1210,6 @@ spec:
   selector:
       app.kubernetes.io/instance: vulcan
       app.kubernetes.io/name: ui
----
-# Source: vulcan/templates/vulndb/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: myrelease-vulcan-vulndb
-  labels:
-    helm.sh/chart: vulcan-0.3.1
-    app.kubernetes.io/instance: vulcan
-    app.kubernetes.io/version: "1.16.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: vulndb
-spec:
-  type: ClusterIP
-  ports:
-    - port: 80
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-      app.kubernetes.io/instance: vulcan
-      app.kubernetes.io/name: vulndb
 ---
 # Source: vulcan/templates/vulndbapi/service.yaml
 apiVersion: v1
@@ -3351,6 +3329,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: api
   annotations:
+    nginx.ingress.kubernetes.io/cors-allow-origin: https://www.vulcan.local
+    nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 8m
 spec:
   rules:

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -37,7 +37,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -54,7 +54,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -69,7 +69,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-dogstatsd
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -100,7 +100,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -116,7 +116,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -131,7 +131,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -146,7 +146,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -161,7 +161,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -344,7 +344,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-api-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -388,7 +388,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-crontinuous-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -432,7 +432,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -488,7 +488,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-insights-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -540,7 +540,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-persistence-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -584,7 +584,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-reportsgenerator-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -628,7 +628,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-results-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -672,7 +672,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-scanengine-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -716,7 +716,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-stream-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -760,7 +760,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-ui-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -804,7 +804,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-vulndbapi-proxy
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -997,7 +997,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1019,7 +1019,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1041,7 +1041,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1063,7 +1063,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1085,7 +1085,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1107,7 +1107,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1129,7 +1129,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1151,7 +1151,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1173,7 +1173,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1195,7 +1195,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1217,7 +1217,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1348,7 +1348,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1364,8 +1364,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: api
       annotations:
-        checksum/secrets: 939c4dc2b2a5e2e01476fe9de11887a126f66b038dc5e26e807e71d7de139695
-        checksum/config-proxy: 7cbbc735a40bbfeab2bd60b3e4e584c9cf9bbb5c2543ad3d651884e82875f49c
+        checksum/secrets: 065eb3c116adcd54fb6b7361375402302acf3d1b3a42bf48521c2064703259f6
+        checksum/config-proxy: 430d11cfdf06fd0eeb7753eceb504a40905f5fdf333ba10746c9695dc23f48e4
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -1531,7 +1531,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1547,8 +1547,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: crontinuous
       annotations:
-        checksum/secrets: 5745a7798ddece2adde7e4d0aacaf2273b867391bed2dcf62e2c20c10e24fa27
-        checksum/config-proxy: 8301c4eee9fd614a36fe4daa80caf32cbf3bd1824c565bde1ec95bce48cb01a4
+        checksum/secrets: 9b40d939e5d8851a3d12909611ae088f8695a3a8315494d05b9875f291454bd7
+        checksum/config-proxy: 7a9ff685af6768c75cfc9a7722014b180663701e41032f1bb06e714b50bc63b3
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -1651,7 +1651,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1667,7 +1667,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: goaws
       annotations:
-        checksum/config: d104c56776fcc08f354788ce89a63a430b3ec2edcaabb9cfb1eb2492b0089ef0
+        checksum/config: 9764e49c3c2a2c332977f090ae7144c803f660d265b273af23f6f090e6bcd9b8
     spec:
       containers:
       - name: goaws
@@ -1691,7 +1691,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1707,7 +1707,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: insights
       annotations:
-        checksum/config: 703ed50cec41de44e0e3758a3bef40eb3f407e0dee9da314572ad3ff74d04d58
+        checksum/config: ae78f3bdf3bfc91f4fe4e4f8c9a5457819610ea3baa34204a633a21e45b04113
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -1826,7 +1826,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1925,7 +1925,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1941,8 +1941,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: persistence
       annotations:
-        checksum/secrets: c6e71a21b8cf46061bcc42f125328e081cde2429fbaa2d8dbd931cced795d61a
-        checksum/config-proxy: 58945b489b6c74b3ba3f571c98a03211e54de3e50a74b66af08513373be110e6
+        checksum/secrets: 911c6f86a2ec3decd51314f8838cc54459aa09bf24c0d7577e7bb383e1295554
+        checksum/config-proxy: 3151e6a108ce8bd5b672ea6f322cfdbdb956427df391ef2aebbc022bffb77e0e
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2072,7 +2072,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2088,8 +2088,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: reportsgenerator
       annotations:
-        checksum/secrets: 58fac4f657807fbaa6bea8cdd6f7ba939e77ce2ccc256c2abe5507c520f5ea7f
-        checksum/config-proxy: 89649aeee9c8a9b2c4088e7e6b7bee4c0ded593ab4f6e91a576bb734865548d7
+        checksum/secrets: 106dabcea10ca50a85ae410036c1db26a256198d6e584ce9c12e173d5b4db9d8
+        checksum/config-proxy: c1dd9fc8495a31037e3e64aed4eb09945ecde91a29fd2766c6397a1c0d0c32fb
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2246,7 +2246,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2262,7 +2262,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: results
       annotations:
-        checksum/config-proxy: 251d2ce669b075656d4ef8a27f88765b497795a70c416156988df265d315d3a1
+        checksum/config-proxy: 889a9e304015fded6ad60e3ea92495b8c3b71461039bdb6b414317fbd332e7b0
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2370,7 +2370,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2386,8 +2386,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: scanengine
       annotations:
-        checksum/secrets: 0a5cf4b9a5fcd99b5e70f33c86b947dc4a8155695df436950fdec0b1f2c6d0f3
-        checksum/config-proxy: e058b300bc9a692fbf5ae7184f06984f054330572fd8580753aed227afc6e1f6
+        checksum/secrets: 151cafab84fb11c02713d083259c429c7d3deae2688ba60500e991ce6da9126b
+        checksum/config-proxy: bdfccf5fa5abe44073d6aeb882965d1a15b0b0587d0131fb95a279bcbbfd8e99
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2523,7 +2523,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-sqsexporter
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2577,7 +2577,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2593,7 +2593,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: stream
       annotations:
-        checksum/config-proxy: 5a9e38009bf02dcb037c3e0c1e3e3aa1c69cecc0356c4273afb8de6bb976a69b
+        checksum/config-proxy: ac1119a231287803c9fdb74c0c0e0e123662655f5cca5a15acbfba31c2f20677
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2687,7 +2687,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2703,7 +2703,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: ui
       annotations:
-        checksum/config-proxy: bd854a71f46a654aa37dcf994ee5c0889aec9daa629cbeefea2323d9ad21b4c4
+        checksum/config-proxy: 3af3dd568f76e45913660b45da6ca7cb5a9de0491e386a8a9e7d596c0528093e
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2785,7 +2785,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2801,7 +2801,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: vulndb
       annotations:
-        checksum/secrets: 2af180275f9188530a217b7361a3dff8b1a8c348d91798db7486d586b8ac5906
+        checksum/secrets: 56951f86d2133e0adaefad713ca6f7f18f6c5f4fba7ba7e2efa10b78f397b41a
         
     spec:
       initContainers:
@@ -2869,7 +2869,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2885,8 +2885,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: vulndbapi
       annotations:
-        checksum/secrets: 0a84f97fc338e1c8c7f9f657490d818fdee28062f86c09b67cd7f4101e389e01
-        checksum/config-proxy: fc3ec57d48b35ccb949ae4ff31659114383eaca7a53fec581c8f7e3b83a65bb0
+        checksum/secrets: 4163b873407098a876b91b1eab8f315129181f1c8a3b6cc93878faf6cafdacab
+        checksum/config-proxy: a1911e97cfd1eabe6006feb8320c8f7aa75525e5bb246f9458aa1fc9e8b44e2b
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -3323,7 +3323,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3348,7 +3348,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3369,7 +3369,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3398,7 +3398,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3419,7 +3419,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3440,7 +3440,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3464,7 +3464,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3485,7 +3485,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.3.1
+    helm.sh/chart: vulcan-0.3.2
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm

--- a/stable/vulcan/Chart.yaml
+++ b/stable/vulcan/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/vulcan/README.md
+++ b/stable/vulcan/README.md
@@ -26,10 +26,10 @@ A Helm chart for deploying Vulcan
 |-----|------|---------|-------------|
 | global.domain | string | `"vulcan.local"` |  |
 | global.region | string | `"local"` |  |
-| anchors | object | `{"comp":{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":50,"targetMemoryUtilizationPercentage":null},"containerPort":8080,"extraEnv":{},"fullnameOverride":"","image":{"pullPolicy":"Always"},"imagePullSecrets":[],"ingress":{"annotations":{},"enabled":false,"hosts":[],"tls":[]},"lifecycle":{"preStopSleep":30},"livenessProbe":{"enabled":true,"failureThreshold":10,"initialDelaySeconds":5,"path":null,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":3},"nameOverride":"","nodeSelector":{},"podSecurityContext":{},"proxy":{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null},"readinessProbe":{"enabled":true,"failureThreshold":5,"initialDelaySeconds":5,"path":null,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":3},"replicaCount":null,"resources":{},"securityContext":{},"service":{"port":80,"portName":null,"protocol":"TCP","targetPort":null,"type":"ClusterIP"},"tolerations":[]},"db":{"ca":null,"host":null,"name":null,"password":"TBD","port":5432,"sslMode":"disable","user":null},"dogstatsd":{"enabled":true,"image":{"repository":"datadog/dogstatsd","tag":"7.27.0"}}}` | Anchors |
+| anchors | object | `{"comp":{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":50,"targetMemoryUtilizationPercentage":null},"containerPort":8080,"extraEnv":{},"fullnameOverride":"","image":{"pullPolicy":"Always"},"imagePullSecrets":[],"ingress":{"annotations":{},"enabled":false,"hosts":[],"tls":[]},"lifecycle":{"preStopSleep":30},"livenessProbe":{"enabled":true,"failureThreshold":10,"initialDelaySeconds":5,"path":null,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":3},"nameOverride":"","nodeSelector":{},"podSecurityContext":{},"proxy":{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null},"readinessProbe":{"enabled":true,"failureThreshold":5,"initialDelaySeconds":5,"path":null,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":3},"replicaCount":null,"resources":{},"securityContext":{},"service":{"port":80,"portName":null,"protocol":"TCP","targetPort":null,"type":"ClusterIP"},"tolerations":[]},"db":{"ca":null,"host":null,"name":null,"password":"TBD","port":5432,"sslMode":"disable","user":null},"dogstatsd":{"enabled":true,"image":{"repository":"datadog/dogstatsd","tag":"7.27.0"}}}` | Anchors |
 | anchors.db | object | `{"ca":null,"host":null,"name":null,"password":"TBD","port":5432,"sslMode":"disable","user":null}` | postgres database settings |
 | anchors.comp.extraEnv | object | `{}` | custom env variables |
-| anchors.comp.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| anchors.comp.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | anchors.comp.livenessProbe | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":5,"path":null,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":3}` | liveness settings |
 | anchors.comp.readinessProbe | object | `{"enabled":true,"failureThreshold":5,"initialDelaySeconds":5,"path":null,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":3}` | readiness settings |
 | anchors.comp.readinessProbe.path | string | `nil` | defaults to healthcheckPath |
@@ -61,7 +61,7 @@ A Helm chart for deploying Vulcan
 | goaws.<<.replicaCount | string | `nil` |  |
 | goaws.<<.image.pullPolicy | string | `"Always"` |  |
 | goaws.<<.extraEnv | object | `{}` | custom env variables |
-| goaws.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| goaws.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | goaws.<<.podSecurityContext | object | `{}` |  |
 | goaws.<<.securityContext | object | `{}` |  |
 | goaws.<<.imagePullSecrets | list | `[]` |  |
@@ -100,7 +100,7 @@ A Helm chart for deploying Vulcan
 | results.<<.replicaCount | string | `nil` |  |
 | results.<<.image.pullPolicy | string | `"Always"` |  |
 | results.<<.extraEnv | object | `{}` | custom env variables |
-| results.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| results.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | results.<<.podSecurityContext | object | `{}` |  |
 | results.<<.securityContext | object | `{}` |  |
 | results.<<.imagePullSecrets | list | `[]` |  |
@@ -136,7 +136,7 @@ A Helm chart for deploying Vulcan
 | persistence.<<.replicaCount | string | `nil` |  |
 | persistence.<<.image.pullPolicy | string | `"Always"` |  |
 | persistence.<<.extraEnv | object | `{}` | custom env variables |
-| persistence.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| persistence.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | persistence.<<.podSecurityContext | object | `{}` |  |
 | persistence.<<.securityContext | object | `{}` |  |
 | persistence.<<.imagePullSecrets | list | `[]` |  |
@@ -173,7 +173,7 @@ A Helm chart for deploying Vulcan
 | stream.<<.replicaCount | string | `nil` |  |
 | stream.<<.image.pullPolicy | string | `"Always"` |  |
 | stream.<<.extraEnv | object | `{}` | custom env variables |
-| stream.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| stream.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | stream.<<.podSecurityContext | object | `{}` |  |
 | stream.<<.securityContext | object | `{}` |  |
 | stream.<<.imagePullSecrets | list | `[]` |  |
@@ -210,7 +210,7 @@ A Helm chart for deploying Vulcan
 | api.<<.replicaCount | string | `nil` |  |
 | api.<<.image.pullPolicy | string | `"Always"` |  |
 | api.<<.extraEnv | object | `{}` | custom env variables |
-| api.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| api.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | api.<<.podSecurityContext | object | `{}` |  |
 | api.<<.securityContext | object | `{}` |  |
 | api.<<.imagePullSecrets | list | `[]` |  |
@@ -274,7 +274,7 @@ A Helm chart for deploying Vulcan
 | crontinuous.<<.replicaCount | string | `nil` |  |
 | crontinuous.<<.image.pullPolicy | string | `"Always"` |  |
 | crontinuous.<<.extraEnv | object | `{}` | custom env variables |
-| crontinuous.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| crontinuous.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | crontinuous.<<.podSecurityContext | object | `{}` |  |
 | crontinuous.<<.securityContext | object | `{}` |  |
 | crontinuous.<<.imagePullSecrets | list | `[]` |  |
@@ -311,7 +311,7 @@ A Helm chart for deploying Vulcan
 | scanengine.<<.replicaCount | string | `nil` |  |
 | scanengine.<<.image.pullPolicy | string | `"Always"` |  |
 | scanengine.<<.extraEnv | object | `{}` | custom env variables |
-| scanengine.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| scanengine.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | scanengine.<<.podSecurityContext | object | `{}` |  |
 | scanengine.<<.securityContext | object | `{}` |  |
 | scanengine.<<.imagePullSecrets | list | `[]` |  |
@@ -356,7 +356,7 @@ A Helm chart for deploying Vulcan
 | ui.<<.replicaCount | string | `nil` |  |
 | ui.<<.image.pullPolicy | string | `"Always"` |  |
 | ui.<<.extraEnv | object | `{}` | custom env variables |
-| ui.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| ui.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | ui.<<.podSecurityContext | object | `{}` |  |
 | ui.<<.securityContext | object | `{}` |  |
 | ui.<<.imagePullSecrets | list | `[]` |  |
@@ -391,7 +391,7 @@ A Helm chart for deploying Vulcan
 | insights.<<.replicaCount | string | `nil` |  |
 | insights.<<.image.pullPolicy | string | `"Always"` |  |
 | insights.<<.extraEnv | object | `{}` | custom env variables |
-| insights.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| insights.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | insights.<<.podSecurityContext | object | `{}` |  |
 | insights.<<.securityContext | object | `{}` |  |
 | insights.<<.imagePullSecrets | list | `[]` |  |
@@ -413,7 +413,7 @@ A Helm chart for deploying Vulcan
 | insights.image.tag | string | `"2.0"` |  |
 | insights.image.pullPolicy | string | `"Always"` |  |
 | insights.healthcheckPath | string | `"/healthcheck"` |  |
-| insights.proxy | object | `{"<<":{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null},"cache":{"enabled":true},"enabled":true}` | proxy settings. mandatory for insights |
+| insights.proxy | object | `{"<<":{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null},"cache":{"enabled":true},"enabled":true}` | proxy settings. mandatory for insights |
 | insights.conf.region | string | `nil` |  |
 | insights.conf.log | string | `"false"` |  |
 | insights.conf.private.name | string | `"private"` |  |
@@ -427,7 +427,7 @@ A Helm chart for deploying Vulcan
 | reportsgenerator.<<.replicaCount | string | `nil` |  |
 | reportsgenerator.<<.image.pullPolicy | string | `"Always"` |  |
 | reportsgenerator.<<.extraEnv | object | `{}` | custom env variables |
-| reportsgenerator.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| reportsgenerator.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | reportsgenerator.<<.podSecurityContext | object | `{}` |  |
 | reportsgenerator.<<.securityContext | object | `{}` |  |
 | reportsgenerator.<<.imagePullSecrets | list | `[]` |  |
@@ -483,7 +483,7 @@ A Helm chart for deploying Vulcan
 | metrics.<<.replicaCount | string | `nil` |  |
 | metrics.<<.image.pullPolicy | string | `"Always"` |  |
 | metrics.<<.extraEnv | object | `{}` | custom env variables |
-| metrics.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| metrics.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | metrics.<<.podSecurityContext | object | `{}` |  |
 | metrics.<<.securityContext | object | `{}` |  |
 | metrics.<<.imagePullSecrets | list | `[]` |  |
@@ -530,7 +530,7 @@ A Helm chart for deploying Vulcan
 | vulndbapi.<<.replicaCount | string | `nil` |  |
 | vulndbapi.<<.image.pullPolicy | string | `"Always"` |  |
 | vulndbapi.<<.extraEnv | object | `{}` | custom env variables |
-| vulndbapi.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| vulndbapi.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | vulndbapi.<<.podSecurityContext | object | `{}` |  |
 | vulndbapi.<<.securityContext | object | `{}` |  |
 | vulndbapi.<<.imagePullSecrets | list | `[]` |  |
@@ -559,7 +559,7 @@ A Helm chart for deploying Vulcan
 | vulndb.<<.replicaCount | string | `nil` |  |
 | vulndb.<<.image.pullPolicy | string | `"Always"` |  |
 | vulndb.<<.extraEnv | object | `{}` | custom env variables |
-| vulndb.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| vulndb.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | vulndb.<<.podSecurityContext | object | `{}` |  |
 | vulndb.<<.securityContext | object | `{}` |  |
 | vulndb.<<.imagePullSecrets | list | `[]` |  |
@@ -595,7 +595,7 @@ A Helm chart for deploying Vulcan
 | sqsexporter.<<.replicaCount | string | `nil` |  |
 | sqsexporter.<<.image.pullPolicy | string | `"Always"` |  |
 | sqsexporter.<<.extraEnv | object | `{}` | custom env variables |
-| sqsexporter.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.10-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
+| sqsexporter.<<.proxy | object | `{"cache":{"enabled":false,"maxAge":240,"maxSize":64},"enabled":true,"image":{"repository":"haproxy","tag":"2.3.13-alpine"},"lifecycle":{"preStopSleep":30},"metricsPort":9101,"port":9090,"probe":false,"probeInitialDelay":5,"probePath":"/healthz","probeTimeoutSeconds":3,"resources":{},"timeoutClient":null,"timeoutConnect":null,"timeoutServer":null,"timeoutTunnel":null}` | proxy settings |
 | sqsexporter.<<.podSecurityContext | object | `{}` |  |
 | sqsexporter.<<.securityContext | object | `{}` |  |
 | sqsexporter.<<.imagePullSecrets | list | `[]` |  |

--- a/stable/vulcan/README.md
+++ b/stable/vulcan/README.md
@@ -1,6 +1,6 @@
 # vulcan
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for deploying Vulcan
 

--- a/stable/vulcan/README.md
+++ b/stable/vulcan/README.md
@@ -91,7 +91,6 @@ A Helm chart for deploying Vulcan
 | minio.serviceAccount.create | bool | `false` |  |
 | minio.persistence.enabled | bool | `false` |  |
 | minio.service.port | int | `80` |  |
-| minio.service.type | string | `"NodePort"` |  |
 | minio.accessKey.password | string | `"AKIAIOSFODNN7EXAMPLE"` |  |
 | minio.secretKey.password | string | `"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"` |  |
 | minio.extraEnv[0].name | string | `"MINIO_REGION_NAME"` |  |

--- a/stable/vulcan/templates/vulndb/service.yaml
+++ b/stable/vulcan/templates/vulndb/service.yaml
@@ -1,2 +1,0 @@
-{{- $_ := (set .Values "comp" .Values.vulndb) -}}
-{{- include "common-service" . }}

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -40,7 +40,7 @@ anchors:
       enabled: true
       image:
         repository: haproxy
-        tag: 2.3.10-alpine
+        tag: 2.3.13-alpine
       port: 9090
       metricsPort: 9101
       cache:

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -233,7 +233,6 @@ minio:
     enabled: false
   service:
     port: 80
-    type: NodePort    # To bypass problem with minio.chart
   accessKey:
     password: AKIAIOSFODNN7EXAMPLE
   secretKey:


### PR DESCRIPTION
- Remove useless vulndb service
- minio service back to clusterip
- Add api cors and update tests
- Fix example parameter
- Bump haproxy to 2.3.13-alpine
- Upgrade chart version
