### PR TITLE
Allow customise global program policy configuration

### DIFF
--- a/examples/aws.yaml
+++ b/examples/aws.yaml
@@ -62,6 +62,13 @@ api:
       metadata: https://org.issuer.com/app/appcode/sso/saml/metadata
       trustedDomains: '["vulcan.example.com"]'
     secretKey: apisecretkey
+    globalPolicyConfig:
+      - name: web-scanning-global
+        allowed_assettypes: '[]'
+        blocked_assettypes: '[]'
+        allowed_checks: '["vulcan-zap"]'
+        blocked_checks: '[]'
+        excluding_suffixes: '["-experimental"]'
   db:
     <<: *db
     host: api.postgres.host

--- a/examples/aws.yaml
+++ b/examples/aws.yaml
@@ -64,11 +64,13 @@ api:
     secretKey: apisecretkey
     globalPolicyConfig:
       - name: web-scanning-global
-        allowed_assettypes: '[]'
-        blocked_assettypes: '[]'
-        allowed_checks: '["vulcan-zap"]'
-        blocked_checks: '[]'
-        excluding_suffixes: '["-experimental"]'
+        allowed_assettypes:
+        blocked_assettypes:
+        allowed_checks:
+          - vulcan-zap
+        blocked_checks:
+        excluding_suffixes:
+          - experimental
   db:
     <<: *db
     host: api.postgres.host

--- a/examples/aws.yaml
+++ b/examples/aws.yaml
@@ -62,14 +62,14 @@ api:
       metadata: https://org.issuer.com/app/appcode/sso/saml/metadata
       trustedDomains: '["vulcan.example.com"]'
     secretKey: apisecretkey
-    globalPolicyConfig:
+    globalPolicies:
       - name: web-scanning-global
-        allowed_assettypes:
-        blocked_assettypes:
-        allowed_checks:
+        allowedAssettypes:
+        blockedAssettypes:
+        allowedChecks:
           - vulcan-zap
-        blocked_checks:
-        excluding_suffixes:
+        blockedChecks:
+        excludingSuffixes:
           - experimental
   db:
     <<: *db

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -49,7 +49,13 @@ api:
     saml:
       callback: https://www.vulcan.local/api/v1/login/callback
       trustedDomains: '["www.vulcan.local"]'
-
+    globalPolicyConfig:
+      - name: web-scanning-global
+        allowed_assettypes: '[]'
+        blocked_assettypes: '[]'
+        allowed_checks: '["vulcan-zap"]'
+        blocked_checks: '[]'
+        excluding_suffixes: '["-experimental"]'
   ingress:
     enabled: true
     annotations:

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -49,14 +49,14 @@ api:
     saml:
       callback: https://www.vulcan.local/api/v1/login/callback
       trustedDomains: '["www.vulcan.local"]'
-    globalPolicyConfig:
+    globalPolicies:
       - name: web-scanning-global
-        allowed_assettypes:
-        blocked_assettypes:
-        allowed_checks:
+        allowedAssettypes:
+        blockedAssettypes:
+        allowedChecks:
           - vulcan-zap
-        blocked_checks:
-        excluding_suffixes:
+        blockedChecks:
+        excludingSuffixes:
           - experimental
   ingress:
     enabled: true

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -51,11 +51,13 @@ api:
       trustedDomains: '["www.vulcan.local"]'
     globalPolicyConfig:
       - name: web-scanning-global
-        allowed_assettypes: '[]'
-        blocked_assettypes: '[]'
-        allowed_checks: '["vulcan-zap"]'
-        blocked_checks: '[]'
-        excluding_suffixes: '["-experimental"]'
+        allowed_assettypes:
+        blocked_assettypes:
+        allowed_checks:
+          - vulcan-zap
+        blocked_checks:
+        excluding_suffixes:
+          - experimental
   ingress:
     enabled: true
     annotations:

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -22,7 +22,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -37,7 +37,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-dogstatsd
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -52,7 +52,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -68,7 +68,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -99,7 +99,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -114,7 +114,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -129,7 +129,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -144,7 +144,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -159,7 +159,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-api-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -203,7 +203,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-crontinuous-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -246,7 +246,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -261,7 +261,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-insights-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -313,7 +313,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-persistence-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -357,7 +357,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-reportsgenerator-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -401,7 +401,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-results-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -445,7 +445,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-scanengine-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -489,7 +489,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-stream-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -533,7 +533,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-ui-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -577,7 +577,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-vulndbapi-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -626,7 +626,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -648,7 +648,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -670,7 +670,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -692,7 +692,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -714,7 +714,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -736,7 +736,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -758,7 +758,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -780,7 +780,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -802,7 +802,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -824,7 +824,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -846,7 +846,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -865,8 +865,8 @@ spec:
         extra-label-tag: api-tag-api
         app.kubernetes.io/name: api
       annotations:
-        checksum/secrets: 4b2965d6cd7e00abfdbc0ddaa04efd8c79ee2589623880718d967a9193b18db5
-        checksum/config-proxy: b1f79511df902d1c4f4aa250877668b3fc2eca6fc53c05b92c903db991e56e8c
+        checksum/secrets: 5bbca992a8c9092e48f87b4480959a6dfeaff3b656988f3b6d1dfe31554f8cfd
+        checksum/config-proxy: 26916513e8754012bc05587aa14a2a8078d705d8bd5b0ad3f8e2d3e2c8790e6a
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/APIRole
@@ -1029,7 +1029,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1048,8 +1048,8 @@ spec:
         extra-label: crontinuous
         app.kubernetes.io/name: crontinuous
       annotations:
-        checksum/secrets: 52a4bbb1036776d3303684f3b0b145564cc29d64a24d08e0c4cfe1b0301da0e0
-        checksum/config-proxy: 27abd719fb6539a43df4feedc270a6cc76d5046c5ccd1cf1be05850a328547b6
+        checksum/secrets: f7f63841b401bf3ff67a755210adac2e657974f81d599685a2e92a460308e239
+        checksum/config-proxy: cb937e9c6685d8c24acfcfdca7b4d14d65ebc02ff4ececa2c2adbe6e336e99df
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/CrontinuousRole
@@ -1140,7 +1140,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1158,7 +1158,7 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: insights
       annotations:
-        checksum/config: 14cca85adc5744b6bc619ef4c5c8a08066862fe9a1eb6706a99ddf80ee1ea607
+        checksum/config: 0192dee1b27683b9e095c53a11a0d5c2a4115a9ae3b260008014c9c7d1bd44d9
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/InsightsRole
@@ -1278,7 +1278,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1378,7 +1378,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1396,8 +1396,8 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: persistence
       annotations:
-        checksum/secrets: 54e032d49a60159de771c210e9b7224dc3009267d153a4cedb37f39d374fe372
-        checksum/config-proxy: 13201ad7fd1d4e84da810c0bbe2c5daf7277e96115558005c513ec2a19e0ee48
+        checksum/secrets: 1cfec6540134b0fd58f3222dec4efa0af8aa111a7722e13808b803ff7289a970
+        checksum/config-proxy: 0b01315218059bc2a44c40a5924fca8619d4f3051c515cf6425db5174aaacd24
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/PersistenceRole
@@ -1512,7 +1512,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1530,8 +1530,8 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: reportsgenerator
       annotations:
-        checksum/secrets: cbe2a3f7f759c0ae7d4bfabeaec2bbe97bc12c27bba19be8983c3bf56a094f46
-        checksum/config-proxy: 915adf097de54ec18ddfcbb8c7e03a86d99cfa787ce4d7c76ec5d76b8daad4ba
+        checksum/secrets: 0fd1b986e8dfa687571e2e5110ec718e29e8e6f43454e48b62c00db235ba1346
+        checksum/config-proxy: 6e5c91c64b86b6ab9f6d4ade71094f7dad53e3875c83638170396644daad7bb0
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/ReportsGeneratorRole
@@ -1707,7 +1707,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1725,7 +1725,7 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: results
       annotations:
-        checksum/config-proxy: 1ab1794c792ff40d2a263b396ee55459ffcb3a468803823f6eaaf51ad71870f2
+        checksum/config-proxy: b678500d559cd751c5a828f7aefc3c37be0eb8a48f6cc1708ea57ab3c642a417
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/ResultsRole
@@ -1821,7 +1821,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1839,8 +1839,8 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: scanengine
       annotations:
-        checksum/secrets: 9550935d782fd7007d686b9fc5ef0d7e0be0fac738f4dea1f8e57c89cb2abbce
-        checksum/config-proxy: d4d387927cf4ecc28093ff3b73457832709359dc4e8b98c83484b672e382abac
+        checksum/secrets: c277a2a4ac25114b3e8a66dfc6a1eb5b538b143d115f92c0c5439967ed3c877d
+        checksum/config-proxy: 8617d96893399d8e977d5bebb6f38b4a8d9ead4f4b06890bc91985c0921a5a62
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/ScanEngineRole
@@ -1977,7 +1977,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-sqsexporter
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2032,7 +2032,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2050,8 +2050,8 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: stream
       annotations:
-        checksum/secrets: f49244775e1fa8f7941498d5b8cc2b7d4f3b36023ce0a2d1013271cc2383e24a
-        checksum/config-proxy: 5049bfc1fcffbd83ea2447c039f055995e19008206936d52be1a7e3e1037644d
+        checksum/secrets: 7ca70b0773127382c76c0ab1bd962c6e671cced24f35faa7d55d64bd95796a54
+        checksum/config-proxy: e7739575c453a2eb01ced0503b3205c32d13a229a3635518a7ff3ab13b3e8e26
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/StreamRole
@@ -2152,7 +2152,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2170,7 +2170,7 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: ui
       annotations:
-        checksum/config-proxy: a8e3f609fa8f5b852963fd1acee44e70b9a1f9dfe868c6fb40dfb541a94a6520
+        checksum/config-proxy: 8af442075b1435409a9c63ac380efdf621d4e8f763738fa9f141afd818352014
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2255,7 +2255,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2273,7 +2273,7 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: vulndb
       annotations:
-        checksum/secrets: 39549d2baf1f3ecacbfd06c388f09188b436a3a4b21dea2860caad1ac7136f12
+        checksum/secrets: cd50c1c4eaa36ef28a437ac42237dfac67f5eb0df228197415cc3a0426f28dc2
         
         iam.amazonaws.com/role: arn:aws:iam::000000000000:role/VulnDBRole
     spec:
@@ -2339,7 +2339,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2357,8 +2357,8 @@ spec:
         global-namespace: 'ns'
         app.kubernetes.io/name: vulndbapi
       annotations:
-        checksum/secrets: 13017ca8bd1bcc0ea59177896eb26dbb39ac5cde736cc1f39c0bfcd76fc98da4
-        checksum/config-proxy: 208d3aed79e8d756f70c7dce0de18028186b3441c5b8c75d22c31e657920e770
+        checksum/secrets: 9788b95b47155a1e0711d4f625f599fac3c13c144e38d331f62d4d8a8fd35027
+        checksum/config-proxy: 01a429c205bd74a869f5c5d6810f75bca4f1db77e185d390db493ea155d706b4
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2456,7 +2456,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2480,7 +2480,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2504,7 +2504,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2528,7 +2528,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2552,7 +2552,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2576,7 +2576,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2606,7 +2606,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2642,7 +2642,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2670,7 +2670,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2698,7 +2698,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2727,7 +2727,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -1000,7 +1000,7 @@ spec:
           - name: "GPC_1_BLOCKED_CHECKS"
             value: "[]"
           - name: "GPC_1_EXCLUDING_SUFFIXES"
-            value: "[\"-experimental\"]"
+            value: "[\"experimental\"]"
           
           - name: DOGSTATSD_ENABLED
             value: "true"

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -989,6 +989,18 @@ spec:
             value: "4"
           - name: AWSCATALOGUE_RETRY_INTERVAL
             value: "2"
+          - name: "GPC_1_NAME"
+            value: "web-scanning-global"
+          - name: "GPC_1_ALLOWED_ASSETTYPES"
+            value: "[]"
+          - name: "GPC_1_BLOCKED_ASSETTYPES"
+            value: "[]"
+          - name: "GPC_1_ALLOWED_CHECKS"
+            value: "[\"vulcan-zap\"]"
+          - name: "GPC_1_BLOCKED_CHECKS"
+            value: "[]"
+          - name: "GPC_1_EXCLUDING_SUFFIXES"
+            value: "[\"-experimental\"]"
           
           - name: DOGSTATSD_ENABLED
             value: "true"

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -1486,6 +1486,18 @@ spec:
             value: "1"
           - name: AWSCATALOGUE_RETRY_INTERVAL
             value: "2"
+          - name: "GPC_1_NAME"
+            value: "web-scanning-global"
+          - name: "GPC_1_ALLOWED_ASSETTYPES"
+            value: "[]"
+          - name: "GPC_1_BLOCKED_ASSETTYPES"
+            value: "[]"
+          - name: "GPC_1_ALLOWED_CHECKS"
+            value: "[\"vulcan-zap\"]"
+          - name: "GPC_1_BLOCKED_CHECKS"
+            value: "[]"
+          - name: "GPC_1_EXCLUDING_SUFFIXES"
+            value: "[\"-experimental\"]"
           - name: AWS_SNS_ENDPOINT
             value: "http://myrelease-vulcan-goaws"
           - name: AWS_SQS_ENDPOINT

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -1497,7 +1497,7 @@ spec:
           - name: "GPC_1_BLOCKED_CHECKS"
             value: "[]"
           - name: "GPC_1_EXCLUDING_SUFFIXES"
-            value: "[\"-experimental\"]"
+            value: "[\"experimental\"]"
           - name: AWS_SNS_ENDPOINT
             value: "http://myrelease-vulcan-goaws"
           - name: AWS_SQS_ENDPOINT

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -37,7 +37,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -54,7 +54,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -69,7 +69,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-dogstatsd
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -100,7 +100,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -116,7 +116,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -131,7 +131,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -146,7 +146,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -161,7 +161,7 @@ kind: Secret
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -344,7 +344,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-api-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -388,7 +388,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-crontinuous-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -432,7 +432,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -487,7 +487,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-insights-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -539,7 +539,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-persistence-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -583,7 +583,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-reportsgenerator-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -627,7 +627,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-results-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -671,7 +671,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-scanengine-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -715,7 +715,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-stream-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -759,7 +759,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-ui-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -803,7 +803,7 @@ kind: ConfigMap
 metadata:
   name: myrelease-vulcan-vulndbapi-proxy
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -996,7 +996,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1018,7 +1018,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1040,7 +1040,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1062,7 +1062,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1084,7 +1084,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1106,7 +1106,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1128,7 +1128,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1150,7 +1150,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1172,7 +1172,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1194,7 +1194,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1216,7 +1216,7 @@ kind: Service
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1347,7 +1347,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1363,8 +1363,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: api
       annotations:
-        checksum/secrets: 5b685e8b2a902fd082174ac9cc1fc6d64a71690711d8040ea7285024f8199ea1
-        checksum/config-proxy: 8526f19591575319bd0480b88d6e88a4109e8939d66d32b901678f50b716387f
+        checksum/secrets: f0642a944837204af2e180ae4a249d9071a1534d608a5bc8358e5cafd520f167
+        checksum/config-proxy: 9c7587b67eff0406a570658adefc57a01c3aaf09ec521dce1cd652eff1102302
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -1542,7 +1542,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-crontinuous
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1558,8 +1558,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: crontinuous
       annotations:
-        checksum/secrets: 0ba9321a4bf2cb82df4c23e3c70f197fc2632629e5d667e9240a1ab1b886341e
-        checksum/config-proxy: 27abd719fb6539a43df4feedc270a6cc76d5046c5ccd1cf1be05850a328547b6
+        checksum/secrets: db9bc895023570cc561de3eeec0117f7614b53d265a31b9351bced8fc3a5a61e
+        checksum/config-proxy: cb937e9c6685d8c24acfcfdca7b4d14d65ebc02ff4ececa2c2adbe6e336e99df
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -1662,7 +1662,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1678,7 +1678,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: goaws
       annotations:
-        checksum/config: 0c797f413821154646e3a4927be509ec093853bd69859d6d933843a09e9aad03
+        checksum/config: 5ca8ca289d0ca698d6ef9e8034c3581d809eac546a3ea80e486d04205cb9230e
     spec:
       containers:
       - name: goaws
@@ -1702,7 +1702,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1718,7 +1718,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: insights
       annotations:
-        checksum/config: 14cca85adc5744b6bc619ef4c5c8a08066862fe9a1eb6706a99ddf80ee1ea607
+        checksum/config: 0192dee1b27683b9e095c53a11a0d5c2a4115a9ae3b260008014c9c7d1bd44d9
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -1837,7 +1837,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-metrics
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1936,7 +1936,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -1952,8 +1952,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: persistence
       annotations:
-        checksum/secrets: e23b8b2ce61ae2365bfa04501b7c7a9602c0e81890742b740c87b54d53d33ff8
-        checksum/config-proxy: 13201ad7fd1d4e84da810c0bbe2c5daf7277e96115558005c513ec2a19e0ee48
+        checksum/secrets: ab11165d7eb3263809d1a9944b91e998b46dd0a2f278135416f28e75c83343ea
+        checksum/config-proxy: 0b01315218059bc2a44c40a5924fca8619d4f3051c515cf6425db5174aaacd24
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2083,7 +2083,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-reportsgenerator
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2099,8 +2099,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: reportsgenerator
       annotations:
-        checksum/secrets: 89bfc4b05f966930db1d995815b19e9ec968cc22669657a85a77847afbf31c25
-        checksum/config-proxy: 915adf097de54ec18ddfcbb8c7e03a86d99cfa787ce4d7c76ec5d76b8daad4ba
+        checksum/secrets: 3402ea9a3ccca0ddf8aef9e8b0d969b853205cf1e065c1936c8ad9477f8dae8c
+        checksum/config-proxy: 6e5c91c64b86b6ab9f6d4ade71094f7dad53e3875c83638170396644daad7bb0
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2257,7 +2257,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2273,7 +2273,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: results
       annotations:
-        checksum/config-proxy: 1ab1794c792ff40d2a263b396ee55459ffcb3a468803823f6eaaf51ad71870f2
+        checksum/config-proxy: b678500d559cd751c5a828f7aefc3c37be0eb8a48f6cc1708ea57ab3c642a417
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2381,7 +2381,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-scanengine
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2397,8 +2397,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: scanengine
       annotations:
-        checksum/secrets: 57a95628e80b0007b253ed375abc329b186f44ccc93c05c9da6c47f587d0274c
-        checksum/config-proxy: d4d387927cf4ecc28093ff3b73457832709359dc4e8b98c83484b672e382abac
+        checksum/secrets: 4f9818d8fbbed4f69deb6e5286599d6d49f549eb7b885abd24cffe4f4ab1742e
+        checksum/config-proxy: 8617d96893399d8e977d5bebb6f38b4a8d9ead4f4b06890bc91985c0921a5a62
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2530,7 +2530,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-sqsexporter
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2585,7 +2585,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2601,7 +2601,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: stream
       annotations:
-        checksum/config-proxy: 5049bfc1fcffbd83ea2447c039f055995e19008206936d52be1a7e3e1037644d
+        checksum/config-proxy: e7739575c453a2eb01ced0503b3205c32d13a229a3635518a7ff3ab13b3e8e26
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2695,7 +2695,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2711,7 +2711,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: ui
       annotations:
-        checksum/config-proxy: a8e3f609fa8f5b852963fd1acee44e70b9a1f9dfe868c6fb40dfb541a94a6520
+        checksum/config-proxy: 8af442075b1435409a9c63ac380efdf621d4e8f763738fa9f141afd818352014
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -2793,7 +2793,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndb
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2809,7 +2809,7 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: vulndb
       annotations:
-        checksum/secrets: 05ef121f668d54501cfe068e3e37e915022cbf6c34d33fa6f1e078c38790e2a2
+        checksum/secrets: 3348c53e23855faaa42961d816020afd1f82f5b60e2ad666ca271d58e85294c0
         
     spec:
       initContainers:
@@ -2877,7 +2877,7 @@ kind: Deployment
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -2893,8 +2893,8 @@ spec:
         app.kubernetes.io/instance: vulcan
         app.kubernetes.io/name: vulndbapi
       annotations:
-        checksum/secrets: daa177f67c3ade301c85089baf8899bd236528dbe10e3b921a8d102155ec2020
-        checksum/config-proxy: 967cfdc576ce7d640b6a7fc41b66f89b58d5a5614ea5b43632a91b0ccd5a4807
+        checksum/secrets: 6d718fd2ff6fe7a056b81c62e151358b7cf1a6f0826b25e78e542d19e7bf2368
+        checksum/config-proxy: 80b3ce5192833bfef02abc97ebbcdd97d88eb7872d8c1832d6b92e96dd7fc42a
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9101'
     spec:
@@ -3331,7 +3331,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-api
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3356,7 +3356,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-goaws
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3377,7 +3377,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-insights
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3406,7 +3406,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-persistence
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3427,7 +3427,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-results
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3448,7 +3448,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-stream
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3472,7 +3472,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-ui
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
@@ -3493,7 +3493,7 @@ kind: Ingress
 metadata:
   name: myrelease-vulcan-vulndbapi
   labels:
-    helm.sh/chart: vulcan-0.4.0
+    helm.sh/chart: vulcan-0.4.1
     app.kubernetes.io/instance: vulcan
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm

--- a/stable/vulcan/Chart.yaml
+++ b/stable/vulcan/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/vulcan/README.md
+++ b/stable/vulcan/README.md
@@ -272,7 +272,7 @@ A Helm chart for deploying Vulcan
 | api.conf.awscatalogue.key | string | `"key"` |  |
 | api.conf.awscatalogue.retries | int | `1` |  |
 | api.conf.awscatalogue.retry_interval | int | `2` |  |
-| api.conf.globalPolicyConfig | string | `nil` | array of name/allowed_assettypes/blocked_assettypes/allowed_checks/blocked_checks/excluding_suffixes which allows to customise global program policies |
+| api.conf.globalPolicies | string | `nil` | array of name/allowedAssettypes/blockedAssettypes/allowedChecks/blockedChecks/excludingSuffixes which allows to customise global program policies |
 | api.dogstatsd.image.repository | string | `"datadog/dogstatsd"` |  |
 | api.dogstatsd.image.tag | string | `"7.32.3"` |  |
 | api.dogstatsd.enabled | bool | `true` |  |

--- a/stable/vulcan/README.md
+++ b/stable/vulcan/README.md
@@ -272,6 +272,7 @@ A Helm chart for deploying Vulcan
 | api.conf.awscatalogue.key | string | `"key"` |  |
 | api.conf.awscatalogue.retries | int | `1` |  |
 | api.conf.awscatalogue.retry_interval | int | `2` |  |
+| api.conf.globalPolicyConfig | string | `nil` | array of name/allowed_assettypes/blocked_assettypes/allowed_checks/blocked_checks/excluding_suffixes which allows to customise global program policies |
 | api.dogstatsd.image.repository | string | `"datadog/dogstatsd"` |  |
 | api.dogstatsd.image.tag | string | `"7.32.3"` |  |
 | api.dogstatsd.enabled | bool | `true` |  |

--- a/stable/vulcan/README.md
+++ b/stable/vulcan/README.md
@@ -1,6 +1,6 @@
 # vulcan
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for deploying Vulcan
 

--- a/stable/vulcan/templates/_helpers.tpl
+++ b/stable/vulcan/templates/_helpers.tpl
@@ -64,17 +64,6 @@ Pod labels
 {{- end }}
 {{- end -}}
 
-{{/*
-Encode a json into a string
-*/}}
-{{- define "encodeJson2String" -}}
-  {{- if or (kindIs "slice" .) (kindIs "map" .) -}}
-    {{- . | toJson -}}
-  {{- else -}}
-    {{- . -}}
-  {{- end -}}
-{{- end -}}
-
 {{- define "api.fullname" -}}
 {{- printf "%s-%s" (include "vulcan.fullname" .) .Values.api.name -}}
 {{- end -}}

--- a/stable/vulcan/templates/_helpers.tpl
+++ b/stable/vulcan/templates/_helpers.tpl
@@ -64,6 +64,17 @@ Pod labels
 {{- end }}
 {{- end -}}
 
+{{/*
+Encode a json into a string
+*/}}
+{{- define "encodeJson2String" -}}
+  {{- if or (kindIs "slice" .) (kindIs "map" .) -}}
+    {{- . | toJson -}}
+  {{- else -}}
+    {{- . -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "api.fullname" -}}
 {{- printf "%s-%s" (include "vulcan.fullname" .) .Values.api.name -}}
 {{- end -}}

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -87,19 +87,19 @@ spec:
             value: {{ .Values.comp.conf.awscatalogue.retries | quote }}
           - name: AWSCATALOGUE_RETRY_INTERVAL
             value: {{ .Values.comp.conf.awscatalogue.retry_interval| quote }}
-          {{- range $index, $value := .Values.comp.conf.globalPolicyConfig }}
+          {{- range $index, $value := .Values.comp.conf.globalPolicies }}
           - name: "GPC_{{ add1 $index }}_NAME"
             value: {{ $value.name | quote }}
           - name: "GPC_{{ add1 $index }}_ALLOWED_ASSETTYPES"
-            value: {{ default list $value.allowed_asettypes | include "encodeJson2String" | quote }}
+            value: {{ default list $value.allowedAsettypes | toJson | quote }}
           - name: "GPC_{{ add1 $index }}_BLOCKED_ASSETTYPES"
-            value: {{ default list $value.blocked_asettypes | include "encodeJson2String" | quote }}
+            value: {{ default list $value.blockedAsettypes | toJson | quote }}
           - name: "GPC_{{ add1 $index }}_ALLOWED_CHECKS"
-            value: {{ default list $value.allowed_checks | include "encodeJson2String" | quote }}
+            value: {{ default list $value.allowedChecks | toJson | quote }}
           - name: "GPC_{{ add1 $index }}_BLOCKED_CHECKS"
-            value: {{ default list $value.blocked_checks | include "encodeJson2String" | quote }}
+            value: {{ default list $value.blockedChecks | toJson | quote }}
           - name: "GPC_{{ add1 $index }}_EXCLUDING_SUFFIXES"
-            value: {{ default list $value.excluding_suffixes | include "encodeJson2String" | quote }}
+            value: {{ default list $value.excludingSuffixes | toJson | quote }}
           {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -87,6 +87,20 @@ spec:
             value: {{ .Values.comp.conf.awscatalogue.retries | quote }}
           - name: AWSCATALOGUE_RETRY_INTERVAL
             value: {{ .Values.comp.conf.awscatalogue.retry_interval| quote }}
+          {{- range $index, $value := .Values.comp.conf.globalPolicyConfig }}
+          - name: "GPC_{{ add1 $index }}_NAME"
+            value: {{ $value.name | quote }}
+          - name: "GPC_{{ add1 $index }}_ALLOWED_ASSETTYPES"
+            value: {{ $value.allowed_assettypes | quote }}
+          - name: "GPC_{{ add1 $index }}_BLOCKED_ASSETTYPES"
+            value: {{ $value.blocked_assettypes | quote }}
+          - name: "GPC_{{ add1 $index }}_ALLOWED_CHECKS"
+            value: {{ $value.allowed_checks | quote }}
+          - name: "GPC_{{ add1 $index }}_BLOCKED_CHECKS"
+            value: {{ $value.blocked_checks | quote }}
+          - name: "GPC_{{ add1 $index }}_EXCLUDING_SUFFIXES"
+            value: {{ $value.excluding_suffixes | quote }}
+          {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -91,15 +91,15 @@ spec:
           - name: "GPC_{{ add1 $index }}_NAME"
             value: {{ $value.name | quote }}
           - name: "GPC_{{ add1 $index }}_ALLOWED_ASSETTYPES"
-            value: {{ $value.allowed_assettypes | quote }}
+            value: {{ default list $value.allowed_asettypes | include "encodeJson2String" | quote }}
           - name: "GPC_{{ add1 $index }}_BLOCKED_ASSETTYPES"
-            value: {{ $value.blocked_assettypes | quote }}
+            value: {{ default list $value.blocked_asettypes | include "encodeJson2String" | quote }}
           - name: "GPC_{{ add1 $index }}_ALLOWED_CHECKS"
-            value: {{ $value.allowed_checks | quote }}
+            value: {{ default list $value.allowed_checks | include "encodeJson2String" | quote }}
           - name: "GPC_{{ add1 $index }}_BLOCKED_CHECKS"
-            value: {{ $value.blocked_checks | quote }}
+            value: {{ default list $value.blocked_checks | include "encodeJson2String" | quote }}
           - name: "GPC_{{ add1 $index }}_EXCLUDING_SUFFIXES"
-            value: {{ $value.excluding_suffixes | quote }}
+            value: {{ default list $value.excluding_suffixes | include "encodeJson2String" | quote }}
           {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -387,6 +387,13 @@ api:
       key: key
       retries: 1
       retry_interval: 2
+    # -- array of name/allowed_assettypes/blocked_assettypes/allowed_checks/blocked_checks/excluding_suffixes which allows to customise global program policies
+    globalPolicyConfig:
+      # - name: web-scanning-global
+      #   allowed_checks: '["vulcan-zap", "vulcan-burp"]'
+      #   excluding_suffixes: '["-experimental"]'
+      # - name: default-global
+      #   blocked_checks: '["vulcan-masscan", "vulcan-zap"]'
 
   dogstatsd: *dogstatsd
 

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -390,10 +390,15 @@ api:
     # -- array of name/allowed_assettypes/blocked_assettypes/allowed_checks/blocked_checks/excluding_suffixes which allows to customise global program policies
     globalPolicyConfig:
       # - name: web-scanning-global
-      #   allowed_checks: '["vulcan-zap", "vulcan-burp"]'
-      #   excluding_suffixes: '["-experimental"]'
+      #   allowed_checks:
+      #     - vulcan-zap
+      #     - vulcan-burp
+      #   excluding_suffixes:
+      #     - experimental
       # - name: default-global
-      #   blocked_checks: '["vulcan-masscan", "vulcan-zap"]'
+      #   blocked_checks:
+      #     - vulcan-masscan
+      #     - vulcan-zap
 
   dogstatsd: *dogstatsd
 

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -387,16 +387,16 @@ api:
       key: key
       retries: 1
       retry_interval: 2
-    # -- array of name/allowed_assettypes/blocked_assettypes/allowed_checks/blocked_checks/excluding_suffixes which allows to customise global program policies
-    globalPolicyConfig:
+    # -- array of name/allowedAssettypes/blockedAssettypes/allowedChecks/blockedChecks/excludingSuffixes which allows to customise global program policies
+    globalPolicies:
       # - name: web-scanning-global
-      #   allowed_checks:
+      #   allowedChecks:
       #     - vulcan-zap
       #     - vulcan-burp
-      #   excluding_suffixes:
+      #   excludingSuffixes:
       #     - experimental
       # - name: default-global
-      #   blocked_checks:
+      #   blockedChecks:
       #     - vulcan-masscan
       #     - vulcan-zap
 


### PR DESCRIPTION
This PR enables the capability to configure vulcan-api global program policies though configuration.

You can define these custom global program policy entries in the vulcan-api `globalPolicies` array. Configuration sample:
```yaml
    globalPolicies:
      - name: web-scanning-global
        allowedChecks:
          - vulcan-zap
          - vulcan-burp
```
 
 You can read more information about the values and the behaviour of the configuration [here](https://github.com/adevinta/vulcan-api/pull/45).
 
This [PR](https://github.com/adevinta/vulcan-api/pull/47) changes in the vulcan-api are required in order to be able to use this new vulcan-chart configuration.