### PR TITLE
Move array srings to json

### DIFF
--- a/examples/aws.yaml
+++ b/examples/aws.yaml
@@ -108,8 +108,8 @@ crontinuous:
     crontinuousBucket: s3-vulcan-crontinuous
     enableTeamsWhitelistReport: "false"
     enableTeamsWhitelistScan: "false"
-    teamsWhitelistReport: []
-    teamsWhitelistScan: []
+    teamsWhitelistReport: '["team1", "team2"]'
+    teamsWhitelistScan: [team1, team2]
     vulcanToken: supersecretvulcantoken
     vulcanUser: vulcanuser
   image:
@@ -237,7 +237,7 @@ reportsgenerator:
         vulcanUi: https://www.vulcan.example.com/
     queueArn: arn:aws:sqs:eu-west-1:000000000000:ReportsGenerator
     ses:
-      cc: ["vulcan@example.com"]
+      cc: '["vulcan@example.com"]'
       from: vulcan@example.com
   db:
     <<: *db

--- a/examples/aws.yaml
+++ b/examples/aws.yaml
@@ -60,7 +60,8 @@ api:
       callback: https://www.vulcan.example.com/api/v1/login/callback
       issuer: http://www.issuer.com/appcode
       metadata: https://org.issuer.com/app/appcode/sso/saml/metadata
-      trustedDomains: '["vulcan.example.com"]'
+      trustedDomains:
+      - vulcan.example.com
     secretKey: apisecretkey
     globalPolicies:
       - name: web-scanning-global
@@ -107,8 +108,8 @@ crontinuous:
     crontinuousBucket: s3-vulcan-crontinuous
     enableTeamsWhitelistReport: "false"
     enableTeamsWhitelistScan: "false"
-    teamsWhitelistReport: '[]'
-    teamsWhitelistScan: '[]'
+    teamsWhitelistReport: []
+    teamsWhitelistScan: []
     vulcanToken: supersecretvulcantoken
     vulcanUser: vulcanuser
   image:
@@ -236,7 +237,7 @@ reportsgenerator:
         vulcanUi: https://www.vulcan.example.com/
     queueArn: arn:aws:sqs:eu-west-1:000000000000:ReportsGenerator
     ses:
-      cc: '[''vulcan@example.com'']'
+      cc: ["vulcan@example.com"]
       from: vulcan@example.com
   db:
     <<: *db
@@ -314,9 +315,9 @@ scanengine:
         arn: arn:aws:sqs:eu-west-1:000000000000:V2ChecksGeneric
       other:
       - arn: arn:aws:sqs:eu-west-1:000000000000:V2ChecksTenable
-        checktypes: '["vulcan-nessus"]'
+        checktypes: ["vulcan-nessus"]
       - arn: arn:aws:sqs:eu-west-1:000000000000:V2ChecksBurp
-        checktypes: '["vulcan-burp"]'
+        checktypes: ["vulcan-burp"]
     scansSNS:
       topicArn: arn:aws:sns:eu-west-1:000000000000:Scans
     snsArn: arn:aws:sns:eu-west-1:000000000000:Scans

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -48,7 +48,7 @@ api:
   conf:
     saml:
       callback: https://www.vulcan.local/api/v1/login/callback
-      trustedDomains: '["www.vulcan.local"]'
+      trustedDomains: ["www.vulcan.local"]
     globalPolicies:
       - name: web-scanning-global
         allowedAssettypes:
@@ -70,8 +70,10 @@ api:
 
 crontinuous:
   conf:
-    teamsWhitelistScan: '["team1", "team2"]'
-    teamsWhitelistReport: '["team3"]'
+    teamsWhitelistScan:
+    - team1
+    - team2
+    teamsWhitelistReport: ["team3"]
   ingress:
     enabled: false
 
@@ -110,7 +112,7 @@ reportsgenerator:
         vulcanUi: http://www.vulcan.local/
         proxyEndpoint: http://insights.vulcan.local
     ses:
-      cc: '["tbd@tbd.com"]'
+      cc: ["tbd@tbd.com"]
   ingress:
     enabled: false
 

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -1112,11 +1112,11 @@ spec:
           - name: ENABLE_TEAMS_WHITELIST_SCAN
             value: "false"
           - name: TEAMS_WHITELIST_SCAN
-            value: "[]"
+            value: "[\"team1\",\"team2\"]"
           - name: ENABLE_TEAMS_WHITELIST_REPORT
             value: "false"
           - name: TEAMS_WHITELIST_REPORT
-            value: "[]"
+            value: "[\"team1\", \"team2\"]"
           
           
           envFrom:

--- a/examples/templates/aws.yaml
+++ b/examples/templates/aws.yaml
@@ -1644,7 +1644,7 @@ spec:
           - name: SES_FROM
             value: "vulcan@example.com"
           - name: SES_CC
-            value: "['vulcan@example.com']"
+            value: "[\"vulcan@example.com\"]"
           - name: SCAN_EMAIL_SUBJECT
             value: "Security Overview"
           - name: SCAN_S3_PUBLIC_BUCKET

--- a/examples/templates/local.yaml
+++ b/examples/templates/local.yaml
@@ -1621,7 +1621,7 @@ spec:
           - name: ENABLE_TEAMS_WHITELIST_SCAN
             value: "false"
           - name: TEAMS_WHITELIST_SCAN
-            value: "[\"team1\", \"team2\"]"
+            value: "[\"team1\",\"team2\"]"
           - name: ENABLE_TEAMS_WHITELIST_REPORT
             value: "false"
           - name: TEAMS_WHITELIST_REPORT

--- a/stable/vulcan/README.md
+++ b/stable/vulcan/README.md
@@ -258,9 +258,9 @@ A Helm chart for deploying Vulcan
 | api.conf.saml.metadata | string | `"https://okta/app/TBD/sso/saml/metadata"` |  |
 | api.conf.saml.issuer | string | `"http://okta/TBD"` |  |
 | api.conf.saml.callback | string | `nil` |  |
-| api.conf.saml.trustedDomains | string | `"[]"` |  |
+| api.conf.saml.trustedDomains | list | `[]` |  |
 | api.conf.logLevel | string | `"INFO"` |  |
-| api.conf.defaultOwners | string | `"[]"` |  |
+| api.conf.defaultOwners | list | `[]` |  |
 | api.conf.vulndbapiUrl | string | `nil` |  |
 | api.conf.persistenceHost | string | `nil` |  |
 | api.conf.crontinuousUrl | string | `nil` |  |
@@ -312,9 +312,9 @@ A Helm chart for deploying Vulcan
 | crontinuous.conf.vulcanUser | string | `"tbd"` |  |
 | crontinuous.conf.vulcanApi | string | `nil` |  |
 | crontinuous.conf.enableTeamsWhitelistScan | string | `"false"` |  |
-| crontinuous.conf.teamsWhitelistScan | string | `"[]"` |  |
+| crontinuous.conf.teamsWhitelistScan | list | `[]` |  |
 | crontinuous.conf.enableTeamsWhitelistReport | string | `"false"` |  |
-| crontinuous.conf.teamsWhitelistReport | string | `"[]"` |  |
+| crontinuous.conf.teamsWhitelistReport | list | `[]` |  |
 | scanengine.enabled | bool | `true` |  |
 | scanengine.name | string | `"scanengine"` |  |
 | scanengine.<<.replicaCount | string | `nil` |  |
@@ -485,7 +485,7 @@ A Helm chart for deploying Vulcan
 | reportsgenerator.conf.generators.livereport.emailSubject | string | `nil` |  |
 | reportsgenerator.conf.ses.region | string | `nil` |  |
 | reportsgenerator.conf.ses.from | string | `"tbd@tbd.com"` |  |
-| reportsgenerator.conf.ses.cc | string | `"[\"tbd@tbd.com\"]"` |  |
+| reportsgenerator.conf.ses.cc[0] | string | `"tbd@tbd.com"` |  |
 | reportsgenerator.db | object | `{"<<":{"ca":null,"host":null,"name":null,"password":"TBD","port":5432,"sslMode":"disable","user":null},"name":"reportsgenerator"}` | postgres database settings |
 | reportsgenerator.dogstatsd.image.repository | string | `"datadog/dogstatsd"` |  |
 | reportsgenerator.dogstatsd.image.tag | string | `"7.32.3"` |  |

--- a/stable/vulcan/templates/_helpers.tpl
+++ b/stable/vulcan/templates/_helpers.tpl
@@ -272,3 +272,12 @@ Pod labels
 {{- define "redis.url" -}}
 {{- printf "%s:%s" (include "redis.host" .) (include "redis.port" .) -}}
 {{- end -}}
+
+{{/*
+Converts toJson only if slice/map input.
+This is used to allow backward compatibility with json values encoded as string (i.e. '["a","b"]')
+This support will be deprecated anytime soon.
+*/}}
+{{- define "safeToJson" -}}
+{{- ternary (toJson .) . (any (kindIs "slice" .) (kindIs "map" .)) -}}
+{{- end -}}

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           - name: SAML_CALLBACK
             value: {{ .Values.comp.conf.saml.callback | quote }}
           - name: SAML_TRUSTED_DOMAINS
-            value: {{ .Values.comp.conf.saml.trustedDomains | quote }}
+            value: {{ default list .Values.comp.conf.saml.trustedDomains | toJson | quote }}
           - name: DEFAULT_OWNERS
             value: {{ .Values.comp.conf.defaultOwners | quote }}
           - name: SCANENGINE_URL

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -58,9 +58,9 @@ spec:
           - name: SAML_CALLBACK
             value: {{ .Values.comp.conf.saml.callback | quote }}
           - name: SAML_TRUSTED_DOMAINS
-            value: {{ default list .Values.comp.conf.saml.trustedDomains | toJson | quote }}
+            value: {{ default list .Values.comp.conf.saml.trustedDomains | include "safeToJson" | quote }}
           - name: DEFAULT_OWNERS
-            value: {{ .Values.comp.conf.defaultOwners | quote }}
+            value: {{ default list .Values.comp.conf.defaultOwners | include "safeToJson" | quote }}
           - name: SCANENGINE_URL
             value: {{ .Values.comp.conf.scanengineUrl | default ( printf "%s/v1/" (include "scanengine.url" .) ) | quote }}
           - name: SCHEDULER_URL

--- a/stable/vulcan/templates/crontinuous/deployment.yaml
+++ b/stable/vulcan/templates/crontinuous/deployment.yaml
@@ -44,11 +44,11 @@ spec:
           - name: ENABLE_TEAMS_WHITELIST_SCAN
             value: {{ .Values.comp.conf.enableTeamsWhitelistScan | quote }}
           - name: TEAMS_WHITELIST_SCAN
-            value: {{ .Values.comp.conf.teamsWhitelistScan | quote }}
+            value: {{ default list .Values.comp.conf.teamsWhitelistScan | toJson | quote }}
           - name: ENABLE_TEAMS_WHITELIST_REPORT
             value: {{ .Values.comp.conf.enableTeamsWhitelistReport | quote }}
           - name: TEAMS_WHITELIST_REPORT
-            value: {{ .Values.comp.conf.teamsWhitelistReport | quote }}
+            value: {{ default list .Values.comp.conf.teamsWhitelistReport | toJson | quote }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:

--- a/stable/vulcan/templates/crontinuous/deployment.yaml
+++ b/stable/vulcan/templates/crontinuous/deployment.yaml
@@ -44,11 +44,11 @@ spec:
           - name: ENABLE_TEAMS_WHITELIST_SCAN
             value: {{ .Values.comp.conf.enableTeamsWhitelistScan | quote }}
           - name: TEAMS_WHITELIST_SCAN
-            value: {{ default list .Values.comp.conf.teamsWhitelistScan | toJson | quote }}
+            value: {{ default list .Values.comp.conf.teamsWhitelistScan | include "safeToJson" | quote }}
           - name: ENABLE_TEAMS_WHITELIST_REPORT
             value: {{ .Values.comp.conf.enableTeamsWhitelistReport | quote }}
           - name: TEAMS_WHITELIST_REPORT
-            value: {{ default list .Values.comp.conf.teamsWhitelistReport | toJson | quote }}
+            value: {{ default list .Values.comp.conf.teamsWhitelistReport | include "safeToJson" | quote }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:

--- a/stable/vulcan/templates/reportsgenerator/deployment.yaml
+++ b/stable/vulcan/templates/reportsgenerator/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - name: SES_FROM
             value: {{ .Values.comp.conf.ses.from | quote }}
           - name: SES_CC
-            value: {{ default list .Values.comp.conf.ses.cc | toJson | quote }}
+            value: {{ default list .Values.comp.conf.ses.cc | include "safeToJson" | quote }}
           - name: SCAN_EMAIL_SUBJECT
             value: {{ .Values.comp.conf.generators.scan.emailSubject | quote }}
           - name: SCAN_S3_PUBLIC_BUCKET

--- a/stable/vulcan/templates/reportsgenerator/deployment.yaml
+++ b/stable/vulcan/templates/reportsgenerator/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - name: SES_FROM
             value: {{ .Values.comp.conf.ses.from | quote }}
           - name: SES_CC
-            value: {{ .Values.comp.conf.ses.cc | quote }}
+            value: {{ default list .Values.comp.conf.ses.cc | toJson | quote }}
           - name: SCAN_EMAIL_SUBJECT
             value: {{ .Values.comp.conf.generators.scan.emailSubject | quote }}
           - name: SCAN_S3_PUBLIC_BUCKET

--- a/stable/vulcan/templates/scanengine/deployment.yaml
+++ b/stable/vulcan/templates/scanengine/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           - name: "QUEUES_{{ add1 $index }}_ARN"
             value: {{ $value.arn | quote }}
           - name: "QUEUES_{{ add1 $index }}_CHECKTYPES"
-            value: {{ default list $value.checktypes | toJson | quote }}
+            value: {{ default list $value.checktypes | include "safeToJson" | quote }}
           {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:

--- a/stable/vulcan/templates/scanengine/deployment.yaml
+++ b/stable/vulcan/templates/scanengine/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           - name: "QUEUES_{{ add1 $index }}_ARN"
             value: {{ $value.arn | quote }}
           - name: "QUEUES_{{ add1 $index }}_CHECKTYPES"
-            value: {{ $value.checktypes | quote }}
+            value: {{ default list $value.checktypes | toJson | quote }}
           {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -372,9 +372,9 @@ api:
       metadata: https://okta/app/TBD/sso/saml/metadata
       issuer: http://okta/TBD
       callback:   # https://vulcan-api/api/v1/login/callback
-      trustedDomains: '[]'  # '["vulcan-api"]'
+      trustedDomains: []  # ["vulcan-api"]
     logLevel: INFO
-    defaultOwners: '[]'  # '["owner1","owner2"]'
+    defaultOwners: []  # ["owner1","owner2"]
     vulndbapiUrl:   # http://vulnerabilitydbapi
     persistenceHost:
     crontinuousUrl:
@@ -428,9 +428,9 @@ crontinuous:
     vulcanUser: tbd
     vulcanApi:    # http://host/api
     enableTeamsWhitelistScan: "false"
-    teamsWhitelistScan: '[]'
+    teamsWhitelistScan: []
     enableTeamsWhitelistReport: "false"
-    teamsWhitelistReport: '[]'
+    teamsWhitelistReport: []
 
 
 scanengine:
@@ -584,7 +584,8 @@ reportsgenerator:
     ses:
       region:
       from: tbd@tbd.com
-      cc: '["tbd@tbd.com"]'
+      cc: 
+      - tbd@tbd.com
 
   # -- postgres database settings
   db:


### PR DESCRIPTION
Moves json arrays encoded as strings to actual yaml arrays for those values:

```
api.conf.saml.trustedDomains
api.conf.defaultOwners
crontinuous.conf.teamsWhitelistScan
crontinuous.conf.teamsWhitelistReport
reportsgenerator.conf.ses.cc
scanengine.conf.queues.other[].checktypes
```

In this example all three expressions generates the same string 
```yaml
a: '["a","b"]'     # Previous
a: ["a","b"]       # New formats
a: [a,b]
a:
  - a
  - b
```
It provides compatibility with previous format to facilitate the transition, but will be dropped in future releases
