### PR TITLE
fix: compare against the last release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,24 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
+    branches: [master]
 
 jobs:
+
   release:
-    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}      
+
     permissions:
       contents: write
+
     runs-on: ubuntu-latest
+
     steps:
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,16 @@ env:
 
 jobs:
   lint-test:
+
     strategy:
+      fail-fast: false
       matrix:
-        k8s: ["1.25.2"]
+        k8s:
+          - "1.19.16"
+          - "1.25.9"
+          - "1.26.4"
+          - "1.27.2"
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,35 +27,61 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.8.1
+          version: v3.12.0
 
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
+      - name: Test
+        env:
+          KVERSION_LIST: ${{ matrix.k8s }}
+        run: ./test.sh 1
+
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.4.0
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Run chart-testing (lint)
-        run: ct lint --check-version-increment=false
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          ct lint --check-version-increment=false
+
+      - name: Run chart-testing (list-changed)
+        id: changed
+        run: |
+          since=$(git describe --tags --abbrev=0 || git rev-list --max-parents=0 --first-parent HEAD)
+          changed="$(ct list-changed --since "$since")"
+          echo "since=$since changed=$changed"
+          echo "changed=$changed" >> $GITHUB_OUTPUT
+          echo "since=$since" >> $GITHUB_OUTPUT
 
       - name: Create kind cluster
+        if: steps.changed.outputs.changed != ''
         uses: helm/kind-action@v1.7.0
         with:
           node_image: kindest/node:v${{ matrix.k8s }}   # Test against this kubernetes release
-        if: steps.list-changed.outputs.changed == 'true'
+          kubectl_version: v${{ matrix.k8s }}
 
       - name: Install in kind
-        if: steps.list-changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed != ''
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo update
-          ct install --helm-extra-set-args "-f examples/local.yaml --set=metrics.enabled=false --set=api.enabled=false"
+          ct install --since ${{ steps.changed.outputs.since }} \
+            --helm-extra-set-args "-f examples/local.yaml --set=metrics.enabled=false --set=api.enabled=false"
+
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.0
+
+      - name: Build
+        env:
+          KVERSION: "1.25.9"
+        run: ./build.sh 1

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ In order to generate a new release, increment the [chart version](https://github
 Before committing changes execute the following commands:
 
 ```sh
-# Update examples/templates and update the charts generated README.md files.
+# Validate the charts.
 ./test.sh -f
+
+# Generate the example / README.md files.
+./build.sh
 
 # Review the updated files and add to the repository.
 git add .

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e 
+
+KVERSION="${KVERSION:-"1.25.9"}"
+
+BASEDIR=$(dirname "$0")
+
+if [ -n "$1" ]
+then
+  find "$BASEDIR/stable" -maxdepth 1 -mindepth 1 -type d -print -exec helm dep update {} \;
+fi
+
+OUTDIR=$BASEDIR/examples/templates
+for f in "$BASEDIR"/examples/*.yaml; do
+  # Generate the examples with the first version
+  fn=$(basename -- "$f")
+  echo "Generating examples in $OUTDIR/$fn based on $KVERSION"
+  helm template myrelease --kube-version "$KVERSION" "$BASEDIR/stable/vulcan" --namespace ns -f "$f" > "$OUTDIR/$fn"
+done
+
+docker run --rm --volume "$(pwd)/stable:/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.11.0 -s file
+
+if [[ "$(git status --porcelain | grep -Ec '^ M (examples/templates|stable/.+/README.md)')" != 0 ]]; then 
+  echo "Changes detected, remember to commit them"
+  git diff
+  exit 1
+else
+  echo "No changes"
+fi


### PR DESCRIPTION
Fixes when to execute the tests.

- in order to decide if there are changes it compares the pushed revision with the latest release.
- The release job is triggered by a success test on master.
- New `build` job to check if generated files are up-to-date.
- Migrated from `kubeval` to `kubeconform` 
- Test on k8s versions from 1.19 onwards as kind-action fails to start with previous k8s releases.

Also it upgrades some dependency versions.