### PR TITLE
Allow create serviceAccounts

### DIFF
--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -33,6 +33,12 @@ results:
         paths: [/]
 
 stream:
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/eks-workshop-carts-dynamo
+    automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ingress:
     annotations:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"

--- a/stable/vulcan/templates/_common.tpl
+++ b/stable/vulcan/templates/_common.tpl
@@ -1,5 +1,24 @@
 {{- define "common-manifests" -}}
 {{- include "common-proxy-config-map" . }}
+{{- include "common-serviceaccount" . }}
+{{- end -}}
+
+
+{{- define "common-serviceaccount" -}}
+{{- if .Values.comp.serviceAccount.create}}
+---
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.comp.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ template "vulcan.fullname" . }}-{{ .Values.comp.name }}
+  labels: {{- include "vulcan.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ .Values.comp.name }}
+  {{- if .Values.comp.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.comp.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}
 {{- end -}}
 
 {{- define "common-annotations" -}}
@@ -76,6 +95,10 @@ resources:
 
 
 {{- define "common-deployment-spec" -}}
+{{- if .Values.comp.serviceAccount.create }}
+serviceAccountName: {{ template "vulcan.fullname" . }}-{{ .Values.comp.name }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.comp.automountServiceAccountToken }}
 {{- with .Values.comp.terminationGracePeriodSeconds }}
 terminationGracePeriodSeconds: {{ . }}
 {{- end -}}

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -66,6 +66,13 @@ anchors:
     #   emptyDir:
     #     sizeLimit: 500Mi
 
+    serviceAccount:
+      create: false
+      automountServiceAccountToken: false
+      annotations: {}
+
+    automountServiceAccountToken: false
+
     # -- proxy settings
     proxy: &proxy
       enabled: true


### PR DESCRIPTION
Allows to create serviceAccounts for the deployments

Example usage:
```yaml
stream:
  serviceAccount:
    create: true
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/my-role
```

