### PR TITLE
Leverage oci registries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: write
 
     runs-on: ubuntu-latest
 
@@ -40,3 +41,11 @@ jobs:
           charts_dir: stable
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Publish to ghcr.io
+        run: |
+          helm dep update stable/vulcan
+          OUT=$(mktemp -d)
+          helm package stable/vulcan -d $OUT
+          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          find "$OUT" -name "*.tgz" -exec helm push {} oci://ghcr.io/${{ github.repository }} \;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.13.3
+          version: v3.15.3
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add localstack https://localstack.github.io/helm-charts
           ct lint --check-version-increment=false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.13.3
+          version: v3.15.3
 
       - uses: actions/setup-python@v5
         with:
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.13.3
+          version: v3.15.3
 
       - name: Compare
         run: |

--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ https://adevinta.github.io/vulcan-charts
 
 ## Vulcan Charts
 
-Add the Vulcan repository to Helm:
-
-```sh
-helm repo add vulcan https://adevinta.github.io/vulcan-charts
-```
-
 ### Vulcan
 
 Create the `vulcan` namespace:
@@ -27,7 +21,12 @@ Create a `values.yaml` config file with the parameters or choose one of the file
 Install vulcan application:
 
 ```sh
+# Based on a helm http repository
+helm repo add vulcan https://adevinta.github.io/vulcan-charts
 helm upgrade -i vulcan vulcan/vulcan -f examples/local.yaml --namespace vulcan
+
+# Based on OCI (recommended)
+helm upgrade -i vulcan oci://ghcr.io/adevinta/vulcan-charts/vulcan -f examples/local.yaml --namespace vulcan
 ```
 
 ## Contributors

--- a/stable/vulcan/Chart.yaml
+++ b/stable/vulcan/Chart.yaml
@@ -25,15 +25,15 @@ appVersion: 1.0.0
 dependencies:
 - name: postgresql
   version: 12.5.7
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   condition: postgresql.enabled
 - name: redis
   version: 17.11.5
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   condition: redis.enabled
 - name: minio
   version: 12.6.4
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   condition: minio.enabled
 - name: localstack
   version: 0.6.10


### PR DESCRIPTION
This PR leverages the usage of OCI registries to store charts.

- Declares the chart dependencies in oci format for the ones available (i.e. bitnami).
  - This is much more efficient as there is no need to access the whole huge bitnami repository.
  - It is not available for localstack.
- Publishes the vulcan-charts in `oci://ghcr.io/adevinta/vulcan-charts/vulcan`.
  - This would be the standard way of publishing and we plan to **deprecate** the `helm/chart-releaser-action` based one.