### PR TITLE
Run check workloads based on asynq queues

### DIFF
--- a/stable/vulcan/Chart.yaml
+++ b/stable/vulcan/Chart.yaml
@@ -24,19 +24,19 @@ appVersion: 1.0.0
 
 dependencies:
 - name: postgresql
-  version: 12.5.7
+  version: 16.2.2
   repository: oci://registry-1.docker.io/bitnamicharts
   condition: postgresql.enabled
 - name: redis
-  version: 17.11.5
+  version: 20.3.0
   repository: oci://registry-1.docker.io/bitnamicharts
   condition: redis.enabled
 - name: minio
-  version: 12.6.4
+  version: 14.8.5
   repository: oci://registry-1.docker.io/bitnamicharts
   condition: minio.enabled
 - name: localstack
-  version: 0.6.10
+  version: 0.6.17
   repository: https://localstack.github.io/helm-charts
   condition: localstack.enabled
 

--- a/stable/vulcan/templates/checks/deployment.yaml
+++ b/stable/vulcan/templates/checks/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "vulcan.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-checkgw
+      app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-checkgw  
   template:
     metadata:
       labels: {{- include "vulcan.podLabels" $ | nindent 8 }}
@@ -66,20 +66,36 @@ spec:
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      containers:
+      {{- with $value.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with $value.serviceAccount }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      initContainers:
       - name: check
         image:  {{ $value.image.repository }}:{{ $value.image.tag }}
+        restartPolicy: Always
         envFrom:
         # TODO: set the requiered vars for each check
-        - secretRef:
-            name: vulcan-agent-vars
+        # - secretRef:
+        #     name: vulcan-agent-vars
         env:
         - name: VULCAN_HTTP_PORT
           value: "8080"
+        {{- range $i, $v := $value.vars }}
+        - name: {{ $v }}
+          valueFrom:
+            secretKeyRef:
+              name: vulcan-agent-vars
+              key: {{ $v }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8080
           protocol: TCP
+      containers:
       - name: controller
         image:  {{ $.Values.checks.controller.image.repository }}:{{ $.Values.checks.controller.image.tag }}
         env:
@@ -105,6 +121,10 @@ spec:
             value: {{ $.Values.checks.controller.bucketReports | quote }}
           - name: AWS_S3_PATH_TEMPLATE
             value: {{ $.Values.checks.controller.pathTemplate | quote }}
+          - name: CHECKTYPE_NAME
+            value: {{ $value.image.repository }}
+          - name: CHECKTYPE_VERSION
+            value: {{ $value.image.tag }}
           {{- include "common-container-envs" $ | nindent 10 }}
 ---
 apiVersion: v1
@@ -145,6 +165,29 @@ spec:
   - hosts:
     - {{ $key }}-checks.localhost.direct
     secretName: localhost-direct-tls
+{{- end }}
+{{- if $.Values.checks.keda.enabled }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+spec:
+  minReplicaCount: {{ $value.minReplicaCount | default 0 }}
+  maxReplicaCount: {{ $value.maxReplicaCount | default 5 }}
+  scaleTargetRef:
+    name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+  triggers:
+    - type: redis
+      metadata:
+        address: {{ printf "%s:%s" (include "vulcan.redis.host" $) (include "vulcan.redis.port" $) }}
+        databaseIndex: {{ include "vulcan.redis.db" $ | quote }}
+        listName: {{ printf "asynq:{vulcan-%s}:pending" $key }}
+        listLength: {{ $value.listLength | default 5 | quote }}
+        activationListLength: "1" # optional
+        enableTLS: "false" # optional
+        unsafeSsl: "false" # optional
+        usernameFromEnv: REDIS_USR
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/vulcan/templates/checks/deployment.yaml
+++ b/stable/vulcan/templates/checks/deployment.yaml
@@ -1,0 +1,162 @@
+{{- $_ := (set .Values "comp" .Values.checks) -}}
+{{- if .Values.checks.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vulcan.fullname" $ }}-checkgw
+  labels: {{- include "vulcan.labels" $ | nindent 4 }}
+    app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-checkgw
+spec:
+  selector:
+    matchLabels: {{- include "vulcan.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-checkgw
+  template:
+    metadata:
+      labels: {{- include "vulcan.podLabels" $ | nindent 8 }}
+        app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-checkgw
+    spec:
+      containers:
+      - name: checkgw
+        image:  {{ .Values.checks.gateway.image.repository }}:{{ .Values.checks.gateway.image.tag }}
+        env:
+          - name: REDIS_HOST
+            value: {{ include "vulcan.redis.host" $ | quote }}
+          - name: REDIS_USR
+            value: {{ include "vulcan.redis.username" $ | quote }}
+          - name: REDIS_PORT
+            value: {{ include "vulcan.redis.port" $ | quote }}
+          - name: REDIS_DB
+            value: {{ include "vulcan.redis.db" $ | quote }}
+          - name: AWS_DEFAULT_REGION
+            value: {{ $.Values.global.region | quote }}
+          - name: CHECKS_SQS_ARN
+            value: {{ tpl $.Values.checks.gateway.queueArn $ | quote }}
+          - name: AWS_SQS_ENDPOINT
+            value: {{ include "sqs.url" $ | quote }}
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: root-user
+                name: vulcan-minio
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: root-password
+                name: vulcan-minio
+---
+{{- end }}
+{{- range $key, $value := .Values.checks.checks }}
+{{- if $value.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+  labels: {{- include "vulcan.labels" $ | nindent 4 }}
+    app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+spec:
+  selector:
+    matchLabels: {{- include "vulcan.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+  template:
+    metadata:
+      labels: {{- include "vulcan.podLabels" $ | nindent 8 }}
+        app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+      annotations:
+
+    spec:
+      containers:
+      - name: check
+        image:  {{ $value.image.repository }}:{{ $value.image.tag }}
+        envFrom:
+        # TODO: set the requiered vars for each check
+        - secretRef:
+            name: vulcan-agent-vars
+        env:
+        - name: VULCAN_HTTP_PORT
+          value: "8080"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      - name: controller
+        image:  {{ $.Values.checks.controller.image.repository }}:{{ $.Values.checks.controller.image.tag }}
+        env:
+          - name: REDIS_HOST
+            value: {{ include "vulcan.redis.host" $ | quote }}
+          - name: REDIS_USR
+            value: {{ include "vulcan.redis.username" $ | quote }}
+          - name: REDIS_PORT
+            value: {{ include "vulcan.redis.port" $ | quote }}
+          - name: REDIS_DB
+            value: {{ include "vulcan.redis.db" $ | quote }}
+          - name: CHECK_NAME
+            value: {{ $key }}
+          - name: CHECK_ENDPOINT
+            value: http://localhost:8080
+          - name: CONCURRENCY
+            value: {{ $value.concurrency | quote }}
+          - name: AWS_DEFAULT_REGION
+            value: {{ $.Values.global.region | quote }}
+          - name: CHECKS_SQS_ARN
+            value: {{ tpl $.Values.checks.controller.queueArn $| quote }}
+          - name: AWS_S3_BUCKET
+            value: {{ $.Values.checks.controller.bucketReports | quote }}
+          - name: AWS_S3_PATH_TEMPLATE
+            value: {{ $.Values.checks.controller.pathTemplate | quote }}
+          - name: AWS_S3_ENDPOINT
+            value: {{ include "minio.url" $ | quote }}
+          - name: AWS_SQS_ENDPOINT
+            value: {{ include "sqs.url" $ | quote }}
+          - name: PATH_STYLE
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: root-user
+                name: vulcan-minio
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: root-password
+                name: vulcan-minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+  labels: {{- include "vulcan.labels" $ | nindent 4 }}
+    app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector: {{- include "vulcan.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+{{- if $.Values.checks.ingresEnabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+  labels: {{- include "vulcan.labels" $ | nindent 4 }}
+    app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+spec:
+  rules:
+  - host: {{ $key }}-check.localhost.direct
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - {{ $key }}-checks.localhost.direct
+    secretName: localhost-direct-tls
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/vulcan/templates/checks/deployment.yaml
+++ b/stable/vulcan/templates/checks/deployment.yaml
@@ -61,8 +61,10 @@ spec:
     metadata:
       labels: {{- include "vulcan.podLabels" $ | nindent 8 }}
         app.kubernetes.io/name: {{ include "vulcan.fullname" $ }}-check-{{ $key }}
+      {{- with $.Values.checks.annotations }}
       annotations:
-
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - name: check
@@ -103,21 +105,7 @@ spec:
             value: {{ $.Values.checks.controller.bucketReports | quote }}
           - name: AWS_S3_PATH_TEMPLATE
             value: {{ $.Values.checks.controller.pathTemplate | quote }}
-          - name: AWS_S3_ENDPOINT
-            value: {{ include "minio.url" $ | quote }}
-          - name: AWS_SQS_ENDPOINT
-            value: {{ include "sqs.url" $ | quote }}
-          - name: PATH_STYLE
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                key: root-user
-                name: vulcan-minio
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                key: root-password
-                name: vulcan-minio
+          {{- include "common-container-envs" $ | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/stable/vulcan/templates/scanengine/_config.tpl
+++ b/stable/vulcan/templates/scanengine/_config.tpl
@@ -1,3 +1,6 @@
 {{- define "scanengine-secrets" -}}
 PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- if .Values.comp.conf.queues.redisEnabled }}
+REDIS_PWD: {{ include "vulcan.redis.encryptedPassword" . | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/scanengine/deployment.yaml
+++ b/stable/vulcan/templates/scanengine/deployment.yaml
@@ -70,6 +70,16 @@ spec:
           - name: "QUEUES_{{ add1 $index }}_CHECKTYPES"
             value: {{ $value.checktypes | quote }}
           {{- end }}
+          {{- if .Values.comp.conf.queues.redisEnabled }}
+          - name: REDIS_HOST
+            value: {{ include "vulcan.redis.host" . | quote }}
+          - name: REDIS_USR
+            value: {{ include "vulcan.redis.username" . | quote }}
+          - name: REDIS_PORT
+            value: {{ include "vulcan.redis.port" . | quote }}
+          - name: REDIS_DB
+            value: {{ include "vulcan.redis.db" . | quote }}
+          {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -712,9 +712,10 @@ checks:
     image:
       repository: checks-controller
       tag: dev
-    queueArn: "" # arn:aws:sqs:{{ .Values.global.region }}:{{ .Values.global.accountId }}:VulcanK8SScanEngineCheckStatus
+    queueArn: # arn:aws:sqs:{{ .Values.global.region }}:{{ .Values.global.accountId }}:VulcanK8SScanEngineCheckStatus
     bucketReports: reports
-    pathTemplate: asynq/{{.ScanID}}/{{.CheckID}}.json
+    pathTemplate: asynq/{{.CheckID}}/{{.CheckID}}.json
+  annotations:
   checks: 
     sleep:
       enabled: false
@@ -735,6 +736,10 @@ checks:
     #   - REGISTRY_USERNAME
     #   - REGISTRY_PASSWORD
   ingressEnabled: false
+
+  meta:
+    s3: true
+    sqs: true
 
   redis:
     host:

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -483,6 +483,7 @@ scanengine:
     checksSNS:
       topicArn: arn:aws:sns:{{ .Values.global.region }}:{{ .Values.global.accountId }}:VulcanK8SChecks
     queues:
+      enableRedis: false
       default:
         arn: arn:aws:sqs:{{ .Values.global.region }}:{{ .Values.global.accountId }}:VulcanK8SV2ChecksGeneric
       # -- array of arn/checktypes
@@ -501,6 +502,13 @@ scanengine:
   db:
     <<: *db
     name: scanengine
+
+  redis:
+    host:
+    port:
+    username:
+    password:
+    db:
 
   dogstatsd: *dogstatsd
 

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -699,3 +699,46 @@ extraManifests: {}
   # config2: |
   #   apiVersion: v1
   #   ...
+
+checks:
+  name: checks
+  gateway:
+    enabled: false
+    image:
+      repository: checks-gateway
+      tag: dev
+    queueArn: arn:aws:sqs:{{ .Values.global.region }}:{{ .Values.global.accountId }}:VulcanK8SV2ChecksGeneric
+  controller:
+    image:
+      repository: checks-controller
+      tag: dev
+    queueArn: "" # arn:aws:sqs:{{ .Values.global.region }}:{{ .Values.global.accountId }}:VulcanK8SScanEngineCheckStatus
+    bucketReports: reports
+    pathTemplate: asynq/{{.ScanID}}/{{.CheckID}}.json
+  checks: 
+    sleep:
+      enabled: false
+      concurrency: 3
+      image:
+        repository: vulcansec/vulcan-sleep
+        tag: checkshttp
+      vars: []
+    # trivy:
+    #   concurrency: 10
+    #   image:
+    #     repository: vulcansec/vulcan-trivy
+    #     tag: checkshttp
+    #   vars:
+    #   - GITHUB_ENTERPRISE_ENDPOINT
+    #   - GITHUB_ENTERPRISE_TOKEN
+    #   - REGISTRY_DOMAIN
+    #   - REGISTRY_USERNAME
+    #   - REGISTRY_PASSWORD
+  ingressEnabled: false
+
+  redis:
+    host:
+    port:
+    username:
+    password:
+    db: 

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -716,8 +716,11 @@ checks:
     bucketReports: reports
     pathTemplate: asynq/{{.CheckID}}/{{.CheckID}}.json
   annotations:
+  keda:
+    enabled: false
   checks: 
     sleep:
+      serviceAccount: ""
       enabled: false
       concurrency: 3
       image:
@@ -735,6 +738,10 @@ checks:
     #   - REGISTRY_DOMAIN
     #   - REGISTRY_USERNAME
     #   - REGISTRY_PASSWORD
+      # minReplicaCount: 0
+      # maxReplicaCount: 5
+      # listLength: 10
+
   ingressEnabled: false
 
   meta:


### PR DESCRIPTION
For each check we have:

1. A deployment
  1 .  Check: Container runs the check listening on a port.
  2 . Controller: Container that reads form one queue and interact with the check.
2. A KEDA ScaledObject for controlling the number of replicas based on the Asynq queue.

Also a deployment / service that exposes the checks available to scan engine and vulcan api. This would eventually replace persistence.
 