### PR TITLE
Improve secrets

### DIFF
--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -49,6 +49,9 @@ stream:
         paths: [/]
 
 persistence:
+  db:
+    existingSecret: vulcan-postgresql
+    existingSecretPasswordKey: postgres-password
   ingress:
     enabled: true
     hosts:

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -49,9 +49,6 @@ stream:
         paths: [/]
 
 persistence:
-  db:
-    existingSecret: "{{ .Release.Name }}-postgresql"
-    existingSecretPasswordKey: postgres-password
   ingress:
     enabled: true
     hosts:
@@ -93,9 +90,6 @@ crontinuous:
 scanengine:
   ingress:
     enabled: false
-  db:
-    existingSecret: "{{ .Release.Name }}-postgresql"
-    existingSecretPasswordKey: postgres-password
   conf:
     queues:
       other:
@@ -114,9 +108,6 @@ ui:
         paths: [/]
 
 reportsgenerator:
-  db:
-    existingSecret: "{{ .Release.Name }}-postgresql"
-    existingSecretPasswordKey: postgres-password
   ingress:
     enabled: false
 
@@ -128,9 +119,6 @@ vulndbapi:
         paths: [/]
   conf:
     readReplicaHost:
-  db:
-    existingSecret: "{{ .Release.Name }}-postgresql"
-    existingSecretPasswordKey: postgres-password
 
 tracker:
   ingress:
@@ -141,6 +129,3 @@ tracker:
   conf:
     logLevel: "error"
     awsServerCredentialKey: "/path/to/credentials/"
-  db:
-    existingSecret: "{{ .Release.Name }}-postgresql"
-    existingSecretPasswordKey: postgres-password

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -93,6 +93,9 @@ crontinuous:
 scanengine:
   ingress:
     enabled: false
+  db:
+    existingSecret: vulcan-postgresql
+    existingSecretPasswordKey: postgres-password
   conf:
     queues:
       other:
@@ -111,6 +114,9 @@ ui:
         paths: [/]
 
 reportsgenerator:
+  db:
+    existingSecret: vulcan-postgresql
+    existingSecretPasswordKey: postgres-password
   ingress:
     enabled: false
 
@@ -122,6 +128,9 @@ vulndbapi:
         paths: [/]
   conf:
     readReplicaHost:
+  db:
+    existingSecret: vulcan-postgresql
+    existingSecretPasswordKey: postgres-password
 
 tracker:
   ingress:
@@ -132,3 +141,6 @@ tracker:
   conf:
     logLevel: "error"
     awsServerCredentialKey: "/path/to/credentials/"
+  db:
+    existingSecret: vulcan-postgresql
+    existingSecretPasswordKey: postgres-password

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -50,7 +50,7 @@ stream:
 
 persistence:
   db:
-    existingSecret: vulcan-postgresql
+    existingSecret: "{{ .Release.Name }}-postgresql"
     existingSecretPasswordKey: postgres-password
   ingress:
     enabled: true
@@ -94,7 +94,7 @@ scanengine:
   ingress:
     enabled: false
   db:
-    existingSecret: vulcan-postgresql
+    existingSecret: "{{ .Release.Name }}-postgresql"
     existingSecretPasswordKey: postgres-password
   conf:
     queues:
@@ -115,7 +115,7 @@ ui:
 
 reportsgenerator:
   db:
-    existingSecret: vulcan-postgresql
+    existingSecret: "{{ .Release.Name }}-postgresql"
     existingSecretPasswordKey: postgres-password
   ingress:
     enabled: false
@@ -129,7 +129,7 @@ vulndbapi:
   conf:
     readReplicaHost:
   db:
-    existingSecret: vulcan-postgresql
+    existingSecret: "{{ .Release.Name }}-postgresql"
     existingSecretPasswordKey: postgres-password
 
 tracker:
@@ -142,5 +142,5 @@ tracker:
     logLevel: "error"
     awsServerCredentialKey: "/path/to/credentials/"
   db:
-    existingSecret: vulcan-postgresql
+    existingSecret: "{{ .Release.Name }}-postgresql"
     existingSecretPasswordKey: postgres-password

--- a/stable/vulcan/templates/_configmap.tpl
+++ b/stable/vulcan/templates/_configmap.tpl
@@ -6,7 +6,7 @@ Creates an standard ConfigMap with the content of .Args.template template and an
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "vulcan.fullname" . }}-{{ .Values.comp.name }}{{ .Args.suffix | default "" }}
+  name: {{ template "comp.fullname" . }}{{ .Args.suffix | default "" }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 data:

--- a/stable/vulcan/templates/_helpers.tpl
+++ b/stable/vulcan/templates/_helpers.tpl
@@ -178,11 +178,7 @@ Pod labels
 
 
 {{- define "pg.host" -}}
-  {{- if .Values.postgresql.enabled -}}
-    {{- printf "%s-postgresql" .Release.Name -}}
-  {{- else -}}
-    {{- .Values.comp.db.host -}}
-  {{- end -}}
+{{- ternary (printf "%s-postgresql" .Release.Name) .Values.comp.db.host .Values.postgresql.enabled -}}
 {{- end -}}
 
 {{- define "pg.database" -}}
@@ -190,11 +186,7 @@ Pod labels
 {{- end -}}
 
 {{- define "pg.username" -}}
-  {{- if .Values.postgresql.enabled -}}
-    {{- .Values.postgresql.auth.username -}}
-  {{- else -}}
-    {{- .Values.comp.db.user -}}
-  {{- end -}}
+{{- ternary .Values.postgresql.auth.username .Values.comp.db.user .Values.postgresql.enabled -}}
 {{- end -}}
 
 {{- define "pg.password" -}}
@@ -206,19 +198,11 @@ Pod labels
 {{- end -}}
 
 {{- define "pg.port" -}}
-  {{- if .Values.postgresql.enabled -}}
-    {{- .Values.postgresql.service.port | default "5432" -}}
-  {{- else -}}
-    {{- .Values.comp.db.port | default "5432" -}}
-  {{- end -}}
+{{- ternary .Values.postgresql.service.port .Values.comp.db.port .Values.postgresql.enabled | default "5432" -}}
 {{- end -}}
 
 {{- define "pg.sslMode" -}}
-  {{- if .Values.postgresql.enabled -}}
-    {{- "disable" -}}
-  {{- else -}}
-    {{- .Values.comp.db.sslMode | default "allow" -}}
-  {{- end -}}
+{{- ternary "disable" (.Values.comp.db.sslMode | default "allow") .Values.postgresql.enabled -}}
 {{- end -}}
 
 {{- define "pg.b64ca" -}}
@@ -231,13 +215,28 @@ Pod labels
   {{- include "pg.password" . | b64enc -}}
 {{- end -}}
 
+{{- define "pg.secretName" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- default (printf "%s-postgresql" .Release.Name) (tpl .Values.postgresql.auth.existingSecret $) -}}
+{{- else -}}
+    {{- default (include "comp.fullname" $) .Values.comp.db.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "pg.passwordKey" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- print "postgres-password" -}}
+{{- else -}}
+    {{- if .Values.comp.db.existingSecret -}}
+        {{- printf "%s" .Values.comp.db.secretKey -}}
+    {{- else -}}
+        {{- print "password" -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{- define "vulcan.redis.host" -}}
-  {{- if .Values.redis.enabled -}}
-    {{- printf "%s-redis-master" .Release.Name -}}
-  {{- else -}}
-    {{- .Values.comp.redis.host -}}
-  {{- end -}}
+{{- ternary (printf "%s-redis-master" .Release.Name) .Values.comp.redis.host .Values.redis.enabled -}}
 {{- end -}}
 
 {{- define "vulcan.redis.db" -}}
@@ -245,11 +244,7 @@ Pod labels
 {{- end -}}
 
 {{- define "vulcan.redis.username" -}}
-  {{- if .Values.redis.enabled -}}
-    {{- .Values.redis.username -}}
-  {{- else -}}
-    {{- .Values.comp.redis.username -}}
-  {{- end -}}
+{{- ternary .Values.redis.username .Values.comp.redis.username .Values.redis.enabled -}}
 {{- end -}}
 
 {{- define "vulcan.redis.password" -}}
@@ -261,11 +256,7 @@ Pod labels
 {{- end -}}
 
 {{- define "vulcan.redis.port" -}}
-  {{- if .Values.redis.enabled -}}
-    {{- .Values.redis.master.service.port | default "6379" -}}
-  {{- else -}}
-    {{- .Values.comp.redis.port | default "6379" -}}
-  {{- end -}}
+{{- ternary .Values.redis.master.service.port .Values.comp.redis.port .Values.redis.enabled | default "6379" -}}
 {{- end -}}
 
 {{- define "vulcan.redis.encryptedPassword" -}}

--- a/stable/vulcan/templates/_helpers.tpl
+++ b/stable/vulcan/templates/_helpers.tpl
@@ -114,6 +114,10 @@ Pod labels
 {{- printf "%s-%s" (include "vulcan.fullname" .) .Values.vulndbapi.name -}}
 {{- end -}}
 
+{{- define "comp.fullname" -}}
+{{- printf "%s-%s" (include "vulcan.fullname" .) .Values.comp.name -}}
+{{- end -}}
+
 {{- define "region" -}}
 {{- .Values.global.region -}}
 {{- end -}}

--- a/stable/vulcan/templates/_hpa.yaml
+++ b/stable/vulcan/templates/_hpa.yaml
@@ -10,14 +10,14 @@ apiVersion: autoscaling/v2
 {{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "vulcan.fullname" . }}-{{ .Values.comp.name }}
+  name: {{ template "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "vulcan.fullname" . }}-{{ .Values.comp.name }}
+    name: {{ template "comp.fullname" . }}
   minReplicas: {{ .Values.comp.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.comp.autoscaling.maxReplicas }}
   {{- if semverCompare ">=1.23-0" (include "common.capabilities.kubeVersion" .) }}

--- a/stable/vulcan/templates/_ingress.yaml
+++ b/stable/vulcan/templates/_ingress.yaml
@@ -3,7 +3,7 @@ Standard ingress definition
 */}}
 {{- define "common-ingress" -}}
 {{- if and .Values.comp.enabled .Values.comp.ingress.enabled -}}
-{{- $fullName := printf "%s-%s" (include "vulcan.fullname" . ) .Values.comp.name -}}
+{{- $fullName := (include "comp.fullname" . ) -}}
 {{- $svcPort := .Values.comp.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/stable/vulcan/templates/_secret.tpl
+++ b/stable/vulcan/templates/_secret.tpl
@@ -6,7 +6,7 @@ Creates an standard Secret with the content of .Args.template template and an op
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "vulcan.fullname" . }}-{{ .Values.comp.name }}{{ .Args.suffix | default "" }}
+  name: {{ template "comp.fullname" . }}{{ .Args.suffix | default "" }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 type: Opaque

--- a/stable/vulcan/templates/_secret.tpl
+++ b/stable/vulcan/templates/_secret.tpl
@@ -2,7 +2,7 @@
 Creates an standard Secret with the content of .Args.template template and an optional .Args.suffix name.
 */}}
 {{- define "common-secret" -}}
-{{- if and .Values.comp.enabled }}
+{{- if and .Values.comp.enabled (include .Args.template .) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/vulcan/templates/api/_config.tpl
+++ b/stable/vulcan/templates/api/_config.tpl
@@ -1,7 +1,13 @@
 {{- define "api-secrets" -}}
+{{- if not .Values.comp.db.existingSecret }}
 PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- end }}
+{{- if not .Values.comp.existingSecret }}
 SECRET_KEY: {{ .Values.comp.conf.secretKey | b64enc | quote }}
+{{- end }}
+{{- if not .Values.comp.conf.awscatalogue.existingSecret }}
 AWSCATALOGUE_KEY: {{ .Values.comp.conf.awscatalogue.key | b64enc | quote }}
+{{- end }}
 {{- if .Values.comp.conf.kafka.password }}
 KAFKA_PASS: {{ .Values.comp.conf.kafka.password | b64enc | quote }}
 {{- end }}

--- a/stable/vulcan/templates/api/_config.tpl
+++ b/stable/vulcan/templates/api/_config.tpl
@@ -1,14 +1,14 @@
 {{- define "api-secrets" -}}
-{{- if not .Values.comp.db.existingSecret }}
-PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.comp.db.existingSecret) }}
+{{ .Values.comp.db.passwordKey }}: {{ .Values.comp.db.password | b64enc | quote }}
 {{- end }}
-{{- if not .Values.comp.existingSecret }}
-SECRET_KEY: {{ .Values.comp.conf.secretKey | b64enc | quote }}
+{{- if not .Values.comp.conf.existingSecret }}
+{{ .Values.comp.conf.secretKeyKey }}: {{ .Values.comp.conf.secretKey | b64enc | quote }}
 {{- end }}
 {{- if not .Values.comp.conf.awscatalogue.existingSecret }}
-AWSCATALOGUE_KEY: {{ .Values.comp.conf.awscatalogue.key | b64enc | quote }}
+{{ .Values.comp.conf.awscatalogue.keyKey }}: {{ .Values.comp.conf.awscatalogue.key | b64enc | quote }}
 {{- end }}
-{{- if .Values.comp.conf.kafka.password }}
-KAFKA_PASS: {{ .Values.comp.conf.kafka.password | b64enc | quote }}
+{{- if not .Values.comp.conf.kafka.existingSecret }}
+{{ .Values.comp.conf.kafka.passwordKey }}: {{ .Values.comp.conf.kafka.password | b64enc | quote }}
 {{- end }}
-{{- end -}}
+{{- end }}

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "api.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -111,7 +111,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "api.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -46,10 +46,20 @@ spec:
             value: {{ include "pg.sslMode" . | quote }}
           - name: PG_CA_B64
             value: {{ include "pg.b64ca" . | quote }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: COOKIE_DOMAIN
             value: {{ .Values.comp.conf.cookieDomain | default (include "domain" .) | quote }}
+          - name: SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.conf.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.conf.existingSecretSecretKeyKey | default "SECRET_KEY" }}
           - name: SAML_MEATADATA
             value: {{ .Values.comp.conf.saml.metadata | quote }}
           - name: SAML_ISSUER
@@ -87,7 +97,12 @@ spec:
           - name: AWSCATALOGUE_RETRIES
             value: {{ .Values.comp.conf.awscatalogue.retries | quote }}
           - name: AWSCATALOGUE_RETRY_INTERVAL
-            value: {{ .Values.comp.conf.awscatalogue.retry_interval| quote }}
+            value: {{ .Values.comp.conf.awscatalogue.retry_interval | quote }}
+          - name: AWSCATALOGUE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.conf.awscatalogue.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.conf.awscatalogue.existingSecretKeyKey | default "AWSCATALOGUE_KEY" }}
           {{- range $index, $value := .Values.comp.conf.globalPolicies }}
           - name: "GPC_{{ add1 $index }}_NAME"
             value: {{ $value.name | quote }}
@@ -102,16 +117,20 @@ spec:
           - name: "GPC_{{ add1 $index }}_EXCLUDING_SUFFIXES"
             value: {{ default list $value.excludingSuffixes | toJson | quote }}
           {{- end }}
+          {{- if .Values.comp.conf.kafka.broker }}
           - name: KAFKA_BROKER
             value: {{ .Values.comp.conf.kafka.broker | quote }}
           - name: KAFKA_USER
             value: {{ .Values.comp.conf.kafka.username | quote }}
+          - name: KAFKA_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.conf.kafka.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.conf.kafka.existingSecretPasswordKey | default "KAFKA_PASS" }}
           - name: KAFKA_TOPICS
             value: {{ .Values.comp.conf.kafka.topics | quote }}
+          {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
@@ -58,7 +58,7 @@ spec:
           - name: SECRET_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.conf.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.conf.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.conf.existingSecretSecretKeyKey | default "SECRET_KEY" }}
           - name: SAML_MEATADATA
             value: {{ .Values.comp.conf.saml.metadata | quote }}
@@ -101,7 +101,7 @@ spec:
           - name: AWSCATALOGUE_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.conf.awscatalogue.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.conf.awscatalogue.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.conf.awscatalogue.existingSecretKeyKey | default "AWSCATALOGUE_KEY" }}
           {{- range $index, $value := .Values.comp.conf.globalPolicies }}
           - name: "GPC_{{ add1 $index }}_NAME"
@@ -125,7 +125,7 @@ spec:
           - name: KAFKA_PASS
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.conf.kafka.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.conf.kafka.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.conf.kafka.existingSecretPasswordKey | default "KAFKA_PASS" }}
           - name: KAFKA_TOPICS
             value: {{ .Values.comp.conf.kafka.topics | quote }}

--- a/stable/vulcan/templates/api/deployment.yaml
+++ b/stable/vulcan/templates/api/deployment.yaml
@@ -49,8 +49,8 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: COOKIE_DOMAIN
@@ -58,8 +58,8 @@ spec:
           - name: SECRET_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.conf.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.conf.existingSecretSecretKeyKey | default "SECRET_KEY" }}
+                name: {{ default (include "comp.fullname" .) .Values.comp.conf.existingSecret }}
+                key: {{ .Values.comp.conf.secretKeyKey }}
           - name: SAML_MEATADATA
             value: {{ .Values.comp.conf.saml.metadata | quote }}
           - name: SAML_ISSUER
@@ -101,8 +101,8 @@ spec:
           - name: AWSCATALOGUE_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.conf.awscatalogue.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.conf.awscatalogue.existingSecretKeyKey | default "AWSCATALOGUE_KEY" }}
+                name: {{ default (include "comp.fullname" .) .Values.comp.conf.awscatalogue.existingSecret }}
+                key: {{ .Values.comp.conf.awscatalogue.keyKey }}
           {{- range $index, $value := .Values.comp.conf.globalPolicies }}
           - name: "GPC_{{ add1 $index }}_NAME"
             value: {{ $value.name | quote }}
@@ -125,8 +125,8 @@ spec:
           - name: KAFKA_PASS
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.conf.kafka.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.conf.kafka.existingSecretPasswordKey | default "KAFKA_PASS" }}
+                name: {{ default (include "comp.fullname" .) .Values.comp.conf.kafka.existingSecret }}
+                key: {{ .Values.comp.conf.kafka.passwordKey }}
           - name: KAFKA_TOPICS
             value: {{ .Values.comp.conf.kafka.topics | quote }}
           {{- end }}

--- a/stable/vulcan/templates/crontinuous/_config.tpl
+++ b/stable/vulcan/templates/crontinuous/_config.tpl
@@ -1,3 +1,5 @@
 {{- define "crontinuous-secrets" -}}
+{{- if not .Values.comp.conf.existingSecret }}
 VULCAN_TOKEN: {{ .Values.comp.conf.vulcanToken | b64enc | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/crontinuous/_config.tpl
+++ b/stable/vulcan/templates/crontinuous/_config.tpl
@@ -1,5 +1,5 @@
 {{- define "crontinuous-secrets" -}}
 {{- if not .Values.comp.conf.existingSecret }}
-VULCAN_TOKEN: {{ .Values.comp.conf.vulcanToken | b64enc | quote }}
+{{ .Values.comp.conf.vulcanTokenKey }}: {{ .Values.comp.conf.vulcanToken | b64enc }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/crontinuous/deployment.yaml
+++ b/stable/vulcan/templates/crontinuous/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "crontinuous.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -53,7 +53,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "crontinuous.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/crontinuous/deployment.yaml
+++ b/stable/vulcan/templates/crontinuous/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           - name: VULCAN_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.conf.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.conf.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.conf.existingSecretVulcanTokenKey | default "VULCAN_TOKEN" }}
           - name: VULCAN_USER
             value: {{ .Values.comp.conf.vulcanUser }}

--- a/stable/vulcan/templates/crontinuous/deployment.yaml
+++ b/stable/vulcan/templates/crontinuous/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             value: {{ .Values.comp.conf.crontinuousBucket }}
           - name: VULCAN_API
             value: {{ .Values.comp.conf.vulcanApi | default (include "api.url" .) }}
+          - name: VULCAN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.conf.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.conf.existingSecretVulcanTokenKey | default "VULCAN_TOKEN" }}
           - name: VULCAN_USER
             value: {{ .Values.comp.conf.vulcanUser }}
           - name: ENABLE_TEAMS_WHITELIST_SCAN
@@ -51,9 +56,6 @@ spec:
           - name: TEAMS_WHITELIST_REPORT
             value: {{ .Values.comp.conf.teamsWhitelistReport | quote }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/crontinuous/deployment.yaml
+++ b/stable/vulcan/templates/crontinuous/deployment.yaml
@@ -43,8 +43,8 @@ spec:
           - name: VULCAN_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.conf.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.conf.existingSecretVulcanTokenKey | default "VULCAN_TOKEN" }}
+                name: {{ default (include "comp.fullname" .) .Values.comp.conf.existingSecret }}
+                key: {{ .Values.comp.conf.vulcanTokenKey }}
           - name: VULCAN_USER
             value: {{ .Values.comp.conf.vulcanUser }}
           - name: ENABLE_TEAMS_WHITELIST_SCAN

--- a/stable/vulcan/templates/persistence/_config.tpl
+++ b/stable/vulcan/templates/persistence/_config.tpl
@@ -1,8 +1,8 @@
 {{- define "persistence-secrets" -}}
-{{- if not .Values.comp.db.existingSecret }}
-POSTGRES_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.comp.db.existingSecret) }}
+{{ .Values.comp.db.passwordKey }}: {{ .Values.comp.db.password | b64enc | quote }}
 {{- end }}
-{{- if not .Values.comp.existingSecret }}
-SECRET_KEY_BASE: {{ .Values.comp.conf.secretKeyBase | b64enc | quote  }}
+{{- if not .Values.comp.conf.existingSecret }}
+{{ .Values.comp.conf.secretKeyBaseKey }}: {{ .Values.comp.conf.secretKeyBase | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/persistence/_config.tpl
+++ b/stable/vulcan/templates/persistence/_config.tpl
@@ -1,4 +1,8 @@
 {{- define "persistence-secrets" -}}
+{{- if not .Values.comp.db.existingSecret }}
 POSTGRES_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- end }}
+{{- if not .Values.comp.existingSecret }}
 SECRET_KEY_BASE: {{ .Values.comp.conf.secretKeyBase | b64enc | quote  }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/persistence/deployment.yaml
+++ b/stable/vulcan/templates/persistence/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "persistence.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -53,7 +53,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "persistence.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/persistence/deployment.yaml
+++ b/stable/vulcan/templates/persistence/deployment.yaml
@@ -49,8 +49,8 @@ spec:
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "POSTGRES_PASSWORD" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: RAILS_MAX_THREADS
@@ -58,8 +58,8 @@ spec:
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.conf.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.conf.existingSecretSecretKeyBaseKey | default "SECRET_KEY_BASE" }}
+                name: {{ default (include "comp.fullname" .) .Values.comp.conf.existingSecret }}
+                key: {{ .Values.comp.conf.secretKeyBaseKey }}
         {{- include "common-container-envs" . | nindent 10 }}
           ports:
             - name: {{ include "common-appPortName" . }}

--- a/stable/vulcan/templates/persistence/deployment.yaml
+++ b/stable/vulcan/templates/persistence/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.db.existingSecretPasswordKey | default "POSTGRES_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
@@ -58,8 +58,8 @@ spec:
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.existingSecret (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretSecretKeyBaseKey | default "SECRET_KEY_BASE" }}
+                name: {{ coalesce (tpl .Values.comp.conf.existingSecret .) (include "comp.fullname" .) }}
+                key: {{ .Values.comp.conf.existingSecretSecretKeyBaseKey | default "SECRET_KEY_BASE" }}
         {{- include "common-container-envs" . | nindent 10 }}
           ports:
             - name: {{ include "common-appPortName" . }}

--- a/stable/vulcan/templates/persistence/deployment.yaml
+++ b/stable/vulcan/templates/persistence/deployment.yaml
@@ -46,14 +46,21 @@ spec:
             value: {{ include "pg.sslMode" . | quote }}
           - name: POSTGRES_CA_B64
             value: {{ include "pg.b64ca" . | quote }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "POSTGRES_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: RAILS_MAX_THREADS
             value: {{ .Values.comp.conf.railsMaxThreads | quote }}
+          - name: SECRET_KEY_BASE
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretSecretKeyBaseKey | default "SECRET_KEY_BASE" }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/reportsgenerator/_config.tpl
+++ b/stable/vulcan/templates/reportsgenerator/_config.tpl
@@ -1,5 +1,5 @@
 {{- define "reportsgenerator-secrets" -}}
-{{- if not .Values.comp.db.existingSecret -}}
-PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.comp.db.existingSecret) }}
+{{ .Values.comp.db.passwordKey }}: {{ .Values.comp.db.password | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/reportsgenerator/_config.tpl
+++ b/stable/vulcan/templates/reportsgenerator/_config.tpl
@@ -1,3 +1,5 @@
 {{- define "reportsgenerator-secrets" -}}
+{{- if not .Values.comp.db.existingSecret -}}
 PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/reportsgenerator/deployment.yaml
+++ b/stable/vulcan/templates/reportsgenerator/deployment.yaml
@@ -46,6 +46,11 @@ spec:
             value: {{ include "pg.sslMode" . | quote }}
           - name: PG_CA_B64
             value: {{ include "pg.b64ca" . | quote }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: SQS_QUEUE_ARN
@@ -63,9 +68,6 @@ spec:
           - name: LIVEREPORT_EMAIL_SUBJECT
             value: {{ .Values.comp.conf.generators.livereport.emailSubject | quote }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/reportsgenerator/deployment.yaml
+++ b/stable/vulcan/templates/reportsgenerator/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "reportsgenerator.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -65,7 +65,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "reportsgenerator.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/reportsgenerator/deployment.yaml
+++ b/stable/vulcan/templates/reportsgenerator/deployment.yaml
@@ -49,8 +49,8 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: SQS_QUEUE_ARN

--- a/stable/vulcan/templates/reportsgenerator/deployment.yaml
+++ b/stable/vulcan/templates/reportsgenerator/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}

--- a/stable/vulcan/templates/results/deployment.yaml
+++ b/stable/vulcan/templates/results/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "results.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:

--- a/stable/vulcan/templates/scanengine/_config.tpl
+++ b/stable/vulcan/templates/scanengine/_config.tpl
@@ -1,5 +1,5 @@
 {{- define "scanengine-secrets" -}}
-{{- if not .Values.comp.db.existingSecret }}
-PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.comp.db.existingSecret) }}
+{{ .Values.comp.db.passwordKey }}: {{ .Values.comp.db.password | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/scanengine/_config.tpl
+++ b/stable/vulcan/templates/scanengine/_config.tpl
@@ -1,3 +1,5 @@
 {{- define "scanengine-secrets" -}}
+{{- if not .Values.comp.db.existingSecret }}
 PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/scanengine/deployment.yaml
+++ b/stable/vulcan/templates/scanengine/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "scanengine.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -73,7 +73,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "scanengine.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/scanengine/deployment.yaml
+++ b/stable/vulcan/templates/scanengine/deployment.yaml
@@ -46,6 +46,11 @@ spec:
             value: {{ include "pg.sslMode" . | quote }}
           - name: PG_CA_B64
             value: {{ include "pg.b64ca" . | quote }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: PERSISTENCE_HOST
@@ -71,9 +76,6 @@ spec:
             value: {{ $value.checktypes | quote }}
           {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/scanengine/deployment.yaml
+++ b/stable/vulcan/templates/scanengine/deployment.yaml
@@ -49,8 +49,8 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: PERSISTENCE_HOST

--- a/stable/vulcan/templates/scanengine/deployment.yaml
+++ b/stable/vulcan/templates/scanengine/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}

--- a/stable/vulcan/templates/stream/_config.tpl
+++ b/stable/vulcan/templates/stream/_config.tpl
@@ -1,5 +1,5 @@
 {{- define "stream-secrets" -}}
-{{- if not .Values.comp.redis.existingSecret }}
-REDIS_PWD: {{ include "vulcan.redis.encryptedPassword" . | quote }}
+{{- if and (not .Values.comp.redis.existingSecret) .Values.comp.redis.password }}
+{{ .Values.comp.redis.passwordKey }}: {{ .Values.comp.redis.password | b64enc }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/stream/_config.tpl
+++ b/stable/vulcan/templates/stream/_config.tpl
@@ -1,3 +1,5 @@
 {{- define "stream-secrets" -}}
+{{- if not .Values.comp.redis.existingSecret }}
 REDIS_PWD: {{ include "vulcan.redis.encryptedPassword" . | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/stream/deployment.yaml
+++ b/stable/vulcan/templates/stream/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "stream.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -52,7 +52,7 @@ spec:
         {{- if (include "vulcan.redis.password" .) }}
           envFrom:
           - secretRef:
-              name: {{ include "stream.fullname" . }}
+              name: {{ include "comp.fullname" . }}
         {{- end }}
           ports:
             - name: {{ include "common-appPortName" . }}

--- a/stable/vulcan/templates/stream/deployment.yaml
+++ b/stable/vulcan/templates/stream/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           - name: REDIS_PWD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.redis.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.redis.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.redis.existingSecretPasswordKey | default "REDIS_PWD" }}
         {{- end }}
         {{- include "common-container-envs" . | nindent 10 }}

--- a/stable/vulcan/templates/stream/deployment.yaml
+++ b/stable/vulcan/templates/stream/deployment.yaml
@@ -48,13 +48,11 @@ spec:
             value: {{ include "vulcan.redis.db" . | quote }}
           - name: REDIS_TTL
             value: {{ .Values.comp.conf.ttl | quote }}
-        {{- if or (include "vulcan.redis.password" .) .Values.comp.redis.existingSecret }}
           - name: REDIS_PWD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.redis.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.redis.existingSecretPasswordKey | default "REDIS_PWD" }}
-        {{- end }}
+                name: {{ default (include "comp.fullname" .) .Values.comp.redis.existingSecret }}
+                key: {{ .Values.comp.redis.passwordKey }}
         {{- include "common-container-envs" . | nindent 10 }}
           ports:
             - name: {{ include "common-appPortName" . }}

--- a/stable/vulcan/templates/stream/deployment.yaml
+++ b/stable/vulcan/templates/stream/deployment.yaml
@@ -48,12 +48,14 @@ spec:
             value: {{ include "vulcan.redis.db" . | quote }}
           - name: REDIS_TTL
             value: {{ .Values.comp.conf.ttl | quote }}
-        {{- include "common-container-envs" . | nindent 10 }}
-        {{- if (include "vulcan.redis.password" .) }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
+        {{- if or (include "vulcan.redis.password" .) .Values.comp.redis.existingSecret }}
+          - name: REDIS_PWD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.redis.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.redis.existingSecretPasswordKey | default "REDIS_PWD" }}
         {{- end }}
+        {{- include "common-container-envs" . | nindent 10 }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/tracker/_config.tpl
+++ b/stable/vulcan/templates/tracker/_config.tpl
@@ -1,5 +1,5 @@
 {{- define "tracker-secrets" -}}
-{{- if not .Values.comp.db.existingSecret }}
-PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.comp.db.existingSecret) }}
+{{ .Values.comp.db.passwordKey }}: {{ .Values.comp.db.password | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/tracker/_config.tpl
+++ b/stable/vulcan/templates/tracker/_config.tpl
@@ -1,3 +1,5 @@
 {{- define "tracker-secrets" -}}
+{{- if not .Values.comp.db.existingSecret }}
 PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/tracker/deployment.yaml
+++ b/stable/vulcan/templates/tracker/deployment.yaml
@@ -56,9 +56,6 @@ spec:
           - name: AWS_REGION
             value: {{ .Values.comp.conf.region | default (include "region" .) | quote }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/tracker/deployment.yaml
+++ b/stable/vulcan/templates/tracker/deployment.yaml
@@ -49,6 +49,11 @@ spec:
             value: {{ include "pg.sslMode" . | quote }}
           - name: PG_CA_B64
             value: {{ include "pg.b64ca" . | quote }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: AWSSERVERCREDENTIALS_KEY

--- a/stable/vulcan/templates/tracker/deployment.yaml
+++ b/stable/vulcan/templates/tracker/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "tracker.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -58,7 +58,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "tracker.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/tracker/deployment.yaml
+++ b/stable/vulcan/templates/tracker/deployment.yaml
@@ -52,8 +52,8 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: AWSSERVERCREDENTIALS_KEY

--- a/stable/vulcan/templates/ui/deployment.yaml
+++ b/stable/vulcan/templates/ui/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "ui.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:

--- a/stable/vulcan/templates/vulndb/_config.tpl
+++ b/stable/vulcan/templates/vulndb/_config.tpl
@@ -1,3 +1,5 @@
 {{- define "vulndb-secrets" -}}
+{{- if not .Values.comp.db.existingSecret }}
 PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/vulndb/_config.tpl
+++ b/stable/vulcan/templates/vulndb/_config.tpl
@@ -1,5 +1,5 @@
 {{- define "vulndb-secrets" -}}
-{{- if not .Values.comp.db.existingSecret }}
-PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.comp.db.existingSecret) }}
+{{ .Values.comp.db.passwordKey }}: {{ .Values.comp.db.password | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/vulndb/deployment.yaml
+++ b/stable/vulcan/templates/vulndb/deployment.yaml
@@ -44,6 +44,11 @@ spec:
             value: {{ include "pg.sslMode" . | quote }}
           - name: PG_CA_B64
             value: {{ include "pg.b64ca" . | quote }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: MAX_EVENT_AGE

--- a/stable/vulcan/templates/vulndb/deployment.yaml
+++ b/stable/vulcan/templates/vulndb/deployment.yaml
@@ -81,9 +81,6 @@ spec:
           - name: KAFKA_TOPIC
             value: {{ .Values.comp.conf.kafka.topic | quote }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           volumeMounts:
           {{- include "common-deployment-volumeMounts" . | nindent 12 }}
       volumes:

--- a/stable/vulcan/templates/vulndb/deployment.yaml
+++ b/stable/vulcan/templates/vulndb/deployment.yaml
@@ -47,8 +47,8 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
           - name: MAX_EVENT_AGE

--- a/stable/vulcan/templates/vulndb/deployment.yaml
+++ b/stable/vulcan/templates/vulndb/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "vulndb.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -83,7 +83,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "vulndb.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           volumeMounts:
           {{- include "common-deployment-volumeMounts" . | nindent 12 }}
       volumes:

--- a/stable/vulcan/templates/vulndbapi/_config.tpl
+++ b/stable/vulcan/templates/vulndbapi/_config.tpl
@@ -1,6 +1,5 @@
 {{- define "vulndbapi-secrets" -}}
-{{- if not .Values.comp.db.existingSecret }}
-PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
-PG_PASSWORD_READ: {{ include "pg.encryptedPassword" . | quote }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.comp.db.existingSecret) }}
+{{ .Values.comp.db.passwordKey }}: {{ .Values.comp.db.password | b64enc | quote }}
 {{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/vulndbapi/_config.tpl
+++ b/stable/vulcan/templates/vulndbapi/_config.tpl
@@ -1,4 +1,6 @@
 {{- define "vulndbapi-secrets" -}}
+{{- if not .Values.comp.db.existingSecret }}
 PG_PASSWORD: {{ include "pg.encryptedPassword" . | quote }}
 PG_PASSWORD_READ: {{ include "pg.encryptedPassword" . | quote }}
+{{- end }}
 {{- end -}}

--- a/stable/vulcan/templates/vulndbapi/deployment.yaml
+++ b/stable/vulcan/templates/vulndbapi/deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "vulndbapi.fullname" . }}
+  name: {{ include "comp.fullname" . }}
   labels: {{- include "vulcan.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ .Values.comp.name }}
 spec:
@@ -63,7 +63,7 @@ spec:
         {{- include "common-container-envs" . | nindent 10 }}
           envFrom:
           - secretRef:
-              name: {{ include "vulndbapi.fullname" . }}
+              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/vulndbapi/deployment.yaml
+++ b/stable/vulcan/templates/vulndbapi/deployment.yaml
@@ -44,6 +44,11 @@ spec:
             value: {{ include "pg.port" . | quote }}
           - name: PG_SSLMODE
             value: {{ include "pg.sslMode" . | quote }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
       {{- if .Values.comp.conf.readReplicaHost}}
           - name: PG_HOST_READ
             value: {{ .Values.comp.conf.readReplicaHost | quote }}
@@ -55,15 +60,17 @@ spec:
             value: {{ include "pg.port" . | quote }}
           - name: PG_SSLMODE_READ
             value: {{ include "pg.sslMode" . | quote }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD_READ" }}
       {{- end }}
           - name: PG_CA_B64
             value: {{ include "pg.b64ca" . | quote }}
           - name: LOG_LEVEL
             value: {{ .Values.comp.conf.logLevel | quote }}
         {{- include "common-container-envs" . | nindent 10 }}
-          envFrom:
-          - secretRef:
-              name: {{ include "comp.fullname" . }}
           ports:
             - name: {{ include "common-appPortName" . }}
               containerPort: {{ .Values.comp.containerPort }}

--- a/stable/vulcan/templates/vulndbapi/deployment.yaml
+++ b/stable/vulcan/templates/vulndbapi/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
       {{- if .Values.comp.conf.readReplicaHost}}
           - name: PG_HOST_READ
@@ -60,10 +60,10 @@ spec:
             value: {{ include "pg.port" . | quote }}
           - name: PG_SSLMODE_READ
             value: {{ include "pg.sslMode" . | quote }}
-          - name: PG_PASSWORD
+          - name: PG_PASSWORD_READ
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce .Values.comp.db.existingSecret (include "comp.fullname" .) }}
+                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
                 key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD_READ" }}
       {{- end }}
           - name: PG_CA_B64

--- a/stable/vulcan/templates/vulndbapi/deployment.yaml
+++ b/stable/vulcan/templates/vulndbapi/deployment.yaml
@@ -47,8 +47,8 @@ spec:
           - name: PG_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
       {{- if .Values.comp.conf.readReplicaHost}}
           - name: PG_HOST_READ
             value: {{ .Values.comp.conf.readReplicaHost | quote }}
@@ -63,8 +63,8 @@ spec:
           - name: PG_PASSWORD_READ
             valueFrom:
               secretKeyRef:
-                name: {{ coalesce (tpl .Values.comp.db.existingSecret .) (include "comp.fullname" .) }}
-                key: {{ .Values.comp.db.existingSecretPasswordKey | default "PG_PASSWORD_READ" }}
+                name: {{ include "pg.secretName" . }}
+                key: {{ include "pg.passwordKey" . }}
       {{- end }}
           - name: PG_CA_B64
             value: {{ include "pg.b64ca" . | quote }}

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -18,8 +18,8 @@ anchors:
     host:
     name:
     user:
-    existingSecret: ""
-    existingSecretPasswordKey: ""
+    existingSecret:
+    passwordKey: PG_PASSWORD
     password: TBD
     port: 5432
     sslMode: disable
@@ -333,9 +333,9 @@ persistence:
 
     # -- Name of the existing sectret that contains the secretKeyBase
     # -- If set the secretKeyBase will be ignored
-    existingSecret: ""
-    # -- Name of the key in the secret that contains the secretKeyBase
-    existingSecretSecretKeyBaseKey:
+    existingSecret:
+    # -- Name of the key in the secret that contains the secretKeyBase. Default SECRET_KEY_BASE.
+    secretKeyBaseKey: SECRET_KEY_BASE
 
     railsMaxThreads: 4
 
@@ -362,8 +362,8 @@ stream:
     host:
     port:
     username:
-    existingSecret: ""
-    existingSecretPasswordKey:
+    existingSecret:
+    passwordKey: REDIS_PWD
     password:
     db: 0   # default
 
@@ -399,8 +399,8 @@ api:
       snsArn: arn:aws:sns:{{.Values.global.region}}:{{ .Values.global.accountId }}:VulcanK8SReportsGen
       vulcanUIUrl:
 
-    existingSecret: ""
-    existingSecretSecretKeyKey:
+    existingSecret:
+    secretKeyKey: SECRET_KEY
     secretKey: TBDTBD
 
     cookieDomain:     # default .Values.global.domain
@@ -423,8 +423,8 @@ api:
       kind: None
       url: http://catalogue.example.com
       key: key
-      existingSecret: ""
-      existingSecretKeyKey:
+      existingSecret:
+      keyKey: AWSCATALOGUE_KEY
       retries: 1
       retry_interval: 2
     # -- array of name/allowedAssettypes/blockedAssettypes/allowedChecks/blockedChecks/excludingSuffixes which allows to customise global program policies
@@ -443,9 +443,9 @@ api:
       broker:
       username:
 
-      password:
-      existingSecret: ""
-      existingSecretPasswordKey:
+      password: foo
+      existingSecret:
+      passwordKey: KAFKA_PASS
 
       topics:     # '{assets = "assets"}'
 
@@ -473,9 +473,9 @@ crontinuous:
   conf:
     region:
 
-    existingSecret: ""
-    existingSecretVulcanTokenKey:
     vulcanToken: TBDTBDTBD
+    existingSecret:
+    vulcanTokenKey: VULCAN_TOKEN
 
     crontinuousBucket: crontinuous
     vulcanUser: tbd

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -316,8 +316,8 @@ persistence:
 
   meta:
     s3: true
-    sns: true
-    sqs: true
+    sns: false
+    sqs: false
 
   # -- postgres database settings
   db:

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -18,8 +18,8 @@ anchors:
     host:
     name:
     user:
-    existingSecret:
-    existingSecretPasswordKey:
+    existingSecret: ""
+    existingSecretPasswordKey: ""
     password: TBD
     port: 5432
     sslMode: disable
@@ -333,9 +333,9 @@ persistence:
 
     # -- Name of the existing sectret that contains the secretKeyBase
     # -- If set the secretKeyBase will be ignored
-    existingSecret:
+    existingSecret: ""
     # -- Name of the key in the secret that contains the secretKeyBase
-    existingSecretSecretKeyBaseKey: SECRET_KEY_BASE
+    existingSecretSecretKeyBaseKey:
 
     railsMaxThreads: 4
 
@@ -362,7 +362,7 @@ stream:
     host:
     port:
     username:
-    existingSecret:
+    existingSecret: ""
     existingSecretPasswordKey:
     password:
     db: 0   # default
@@ -399,7 +399,7 @@ api:
       snsArn: arn:aws:sns:{{.Values.global.region}}:{{ .Values.global.accountId }}:VulcanK8SReportsGen
       vulcanUIUrl:
 
-    existingSecret:
+    existingSecret: ""
     existingSecretSecretKeyKey:
     secretKey: TBDTBD
 
@@ -423,7 +423,7 @@ api:
       kind: None
       url: http://catalogue.example.com
       key: key
-      existingSecret:
+      existingSecret: ""
       existingSecretKeyKey:
       retries: 1
       retry_interval: 2
@@ -444,7 +444,7 @@ api:
       username:
 
       password:
-      existingSecret:
+      existingSecret: ""
       existingSecretPasswordKey:
 
       topics:     # '{assets = "assets"}'
@@ -473,7 +473,7 @@ crontinuous:
   conf:
     region:
 
-    existingSecret:
+    existingSecret: ""
     existingSecretVulcanTokenKey:
     vulcanToken: TBDTBDTBD
 

--- a/stable/vulcan/values.yaml
+++ b/stable/vulcan/values.yaml
@@ -18,6 +18,8 @@ anchors:
     host:
     name:
     user:
+    existingSecret:
+    existingSecretPasswordKey:
     password: TBD
     port: 5432
     sslMode: disable
@@ -324,7 +326,17 @@ persistence:
 
   conf:
     logLevel: warn
+
+    # -- Value for the secretKeyBase if not using an existing secret
+    # -- If set, a secret will be created with SECRET_KEY_BASE as key
     secretKeyBase: TBDTBD
+
+    # -- Name of the existing sectret that contains the secretKeyBase
+    # -- If set the secretKeyBase will be ignored
+    existingSecret:
+    # -- Name of the key in the secret that contains the secretKeyBase
+    existingSecretSecretKeyBaseKey: SECRET_KEY_BASE
+
     railsMaxThreads: 4
 
   dogstatsd: *dogstatsd
@@ -350,6 +362,8 @@ stream:
     host:
     port:
     username:
+    existingSecret:
+    existingSecretPasswordKey:
     password:
     db: 0   # default
 
@@ -384,7 +398,11 @@ api:
     reports:
       snsArn: arn:aws:sns:{{.Values.global.region}}:{{ .Values.global.accountId }}:VulcanK8SReportsGen
       vulcanUIUrl:
+
+    existingSecret:
+    existingSecretSecretKeyKey:
     secretKey: TBDTBD
+
     cookieDomain:     # default .Values.global.domain
     saml:
       metadata: https://okta/app/TBD/sso/saml/metadata
@@ -405,6 +423,8 @@ api:
       kind: None
       url: http://catalogue.example.com
       key: key
+      existingSecret:
+      existingSecretKeyKey:
       retries: 1
       retry_interval: 2
     # -- array of name/allowedAssettypes/blockedAssettypes/allowedChecks/blockedChecks/excludingSuffixes which allows to customise global program policies
@@ -422,7 +442,11 @@ api:
     kafka:
       broker:
       username:
+
       password:
+      existingSecret:
+      existingSecretPasswordKey:
+
       topics:     # '{assets = "assets"}'
 
   dogstatsd: *dogstatsd
@@ -448,7 +472,11 @@ crontinuous:
 
   conf:
     region:
+
+    existingSecret:
+    existingSecretVulcanTokenKey:
     vulcanToken: TBDTBDTBD
+
     crontinuousBucket: crontinuous
     vulcanUser: tbd
     vulcanApi:    # http://host/api


### PR DESCRIPTION
This PR allows vulcan to use existing secrets. 

Those secrets could be previously been generated manually, with SealedSecrets, with external-secrets, ...

Provided we have a secret for the db:

```sh
kubectl create secret generic db --from-literal=password=<your_password>
```

We can use that secret:

```yaml
vulndb:
  db:
    existingSecret: db
    existingSecretPasswordKey: password
```
